### PR TITLE
fix(op-steel): Replace unwrap() with proper error handling in l1.rs

### DIFF
--- a/crates/op-steel/src/l1.rs
+++ b/crates/op-steel/src/l1.rs
@@ -87,7 +87,10 @@ where
         .get_block_by_number(block_number.into())
         .hashes()
         .await?;
-    let timestamp = block_response.ok_or(Error::NotYetPropagated)?.header.timestamp;
+    let timestamp = block_response
+        .ok_or(Error::NotYetPropagated)?
+        .header
+        .timestamp;
 
     log::debug!("OP timestamp of beacon commit: {timestamp}");
 


### PR DESCRIPTION
Replace block_response.unwrap() with block_response.ok_or(Error::NotYetPropagated)? to properly handle the case when a block is not found

From https://github.com/risc0/risc0-ethereum/pull/644