### PR TITLE
WEB3-640: Activate Base Sepolia Azul fork at 2026-04-20 18:00 UTC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### ⚡️ Features
 
 - Add Fusaka support.
+- Add Base Sepolia Azul fork support (activation 2026-04-20 18:00 UTC, timestamp `1_776_708_000`). A new `OpSpecId::AZUL` variant installs the Osaka MODEXP (EIP-7823/7883) and P256VERIFY (EIP-7951) precompile upgrades on top of op-revm's Jovian set, since `op_revm::OpSpecId::OSAKA` in 17.0 is still a placeholder.
 - Introduce `EthChainSpec::from_chain_id` and the `define_chain_specs!` macro for efficient, dynamic chain specification lookup. Added `ETH_HOODI_CHAIN_SPEC`.
 - Introduce `Eip2935HistoryCommit` to enable historical state proofs using the EIP-2935 history storage contract. This provides a more direct and efficient alternative to the existing beacon-based `HistoryCommit`.
 - Add a new `precompiles` module with type-safe wrappers for the EIP-2935 `HistoryStorage` and EIP-4788 `BeaconRoots` contracts.
@@ -18,6 +19,7 @@ All notable changes to this project will be documented in this file.
 ### 🚨 Breaking Changes
 
 - **Solidity**: Renamed `CommitmentTooOld` error to `InvalidCommitmentBlockNumber` in `Steel.sol` to better reflect validity checks beyond just age.
+- **`risc0-op-steel`**: Renamed `OpEvmSpecId` → `OpSpecId` (re-exported from `optimism`). The upstream-mirroring `OSAKA` variant has been retired — no chain in the registry activates it. Downstream code should use `OpSpecId::AZUL` for Base chains at or after the Azul fork.
 
 ### 🛠️ Fixes
 

--- a/crates/op-steel/src/optimism/mod.rs
+++ b/crates/op-steel/src/optimism/mod.rs
@@ -15,17 +15,18 @@
 use crate::game::DisputeGameInput;
 use alloy_consensus::{Eip658Value, ReceiptWithBloom, TxReceipt};
 use alloy_eips::{Encodable2718, Typed2718, eip4844, eip7691};
-use alloy_evm::{Database, EvmFactory as AlloyEvmFactory};
+use alloy_evm::{Database, EvmFactory as AlloyEvmFactory, precompiles::PrecompilesMap};
 use alloy_op_evm::OpEvmFactory as AlloyOpEvmFactory;
 use alloy_primitives::{Address, B256, BlockNumber, Bloom, Bytes, ChainId, Sealable, TxKind, U256};
 use alloy_rlp::BufMut;
 use delegate::delegate;
 use op_alloy_consensus::OpReceipt;
-use op_revm::{OpTransaction, spec::OpSpecId};
+use op_revm::{DefaultOp, OpBuilder, OpTransaction};
 use risc0_steel::{
-    BlockInput, CallError, Commitment, EvmBlockHeader, EvmEnv, EvmFactory, EvmSpecId, StateDb,
+    BlockInput, CallError, Commitment, EvmBlockHeader, EvmEnv, EvmFactory, StateDb,
     config::{ChainSpec, ForkCondition},
     revm::{
+        Context,
         context::{BlockEnv, CfgEnv, TxEnv},
         context_interface::block::BlobExcessGasAndPrice,
         inspector::NoOpInspector,
@@ -34,7 +35,11 @@ use risc0_steel::{
     serde::{Eip2718Wrapper, RlpHeader},
 };
 use serde::{Deserialize, Serialize};
-use std::{collections::BTreeMap, error::Error, fmt, sync::LazyLock};
+use std::{collections::BTreeMap, error::Error, sync::LazyLock};
+
+mod spec;
+pub use spec::OpSpecId;
+use spec::azul_precompiles;
 
 #[cfg(feature = "host")]
 mod host;
@@ -45,79 +50,66 @@ pub use host::*;
 /// The OP Mainnet [ChainSpec].
 pub static OP_MAINNET_CHAIN_SPEC: LazyLock<OpChainSpec> = LazyLock::new(|| ChainSpec {
     chain_id: 10,
-    forks: BTreeMap::from(
-        [
-            (OpSpecId::BEDROCK, ForkCondition::Block(105_235_063)),
-            (OpSpecId::REGOLITH, ForkCondition::Timestamp(0)),
-            (OpSpecId::CANYON, ForkCondition::Timestamp(1_704_992_401)),
-            (OpSpecId::ECOTONE, ForkCondition::Timestamp(1_710_374_401)),
-            (OpSpecId::FJORD, ForkCondition::Timestamp(1_720_627_201)),
-            (OpSpecId::GRANITE, ForkCondition::Timestamp(1_726_070_401)),
-            (OpSpecId::HOLOCENE, ForkCondition::Timestamp(1_736_445_601)),
-            (OpSpecId::ISTHMUS, ForkCondition::Timestamp(1_746_806_401)),
-            (OpSpecId::JOVIAN, ForkCondition::Timestamp(1_764_691_201)),
-        ]
-        .map(|(id, cond)| (id.into(), cond)),
-    ),
+    forks: BTreeMap::from([
+        (OpSpecId::BEDROCK, ForkCondition::Block(105_235_063)),
+        (OpSpecId::REGOLITH, ForkCondition::Timestamp(0)),
+        (OpSpecId::CANYON, ForkCondition::Timestamp(1_704_992_401)),
+        (OpSpecId::ECOTONE, ForkCondition::Timestamp(1_710_374_401)),
+        (OpSpecId::FJORD, ForkCondition::Timestamp(1_720_627_201)),
+        (OpSpecId::GRANITE, ForkCondition::Timestamp(1_726_070_401)),
+        (OpSpecId::HOLOCENE, ForkCondition::Timestamp(1_736_445_601)),
+        (OpSpecId::ISTHMUS, ForkCondition::Timestamp(1_746_806_401)),
+        (OpSpecId::JOVIAN, ForkCondition::Timestamp(1_764_691_201)),
+    ]),
 });
 
 /// The OP Sepolia [ChainSpec].
 pub static OP_SEPOLIA_CHAIN_SPEC: LazyLock<OpChainSpec> = LazyLock::new(|| ChainSpec {
     chain_id: 11155420,
-    forks: BTreeMap::from(
-        [
-            (OpSpecId::BEDROCK, ForkCondition::Block(0)),
-            (OpSpecId::REGOLITH, ForkCondition::Timestamp(0)),
-            (OpSpecId::CANYON, ForkCondition::Timestamp(1_699_981_200)),
-            (OpSpecId::ECOTONE, ForkCondition::Timestamp(1_708_534_800)),
-            (OpSpecId::FJORD, ForkCondition::Timestamp(1_716_998_400)),
-            (OpSpecId::GRANITE, ForkCondition::Timestamp(1_723_478_400)),
-            (OpSpecId::HOLOCENE, ForkCondition::Timestamp(1_732_633_200)),
-            (OpSpecId::ISTHMUS, ForkCondition::Timestamp(1_744_905_600)),
-            (OpSpecId::JOVIAN, ForkCondition::Timestamp(1_763_568_001)),
-        ]
-        .map(|(id, cond)| (id.into(), cond)),
-    ),
+    forks: BTreeMap::from([
+        (OpSpecId::BEDROCK, ForkCondition::Block(0)),
+        (OpSpecId::REGOLITH, ForkCondition::Timestamp(0)),
+        (OpSpecId::CANYON, ForkCondition::Timestamp(1_699_981_200)),
+        (OpSpecId::ECOTONE, ForkCondition::Timestamp(1_708_534_800)),
+        (OpSpecId::FJORD, ForkCondition::Timestamp(1_716_998_400)),
+        (OpSpecId::GRANITE, ForkCondition::Timestamp(1_723_478_400)),
+        (OpSpecId::HOLOCENE, ForkCondition::Timestamp(1_732_633_200)),
+        (OpSpecId::ISTHMUS, ForkCondition::Timestamp(1_744_905_600)),
+        (OpSpecId::JOVIAN, ForkCondition::Timestamp(1_763_568_001)),
+    ]),
 });
 
 /// The Base Mainnet [ChainSpec].
 pub static BASE_MAINNET_CHAIN_SPEC: LazyLock<OpChainSpec> = LazyLock::new(|| ChainSpec {
     chain_id: 8453,
-    forks: BTreeMap::from(
-        [
-            (OpSpecId::BEDROCK, ForkCondition::Block(0)),
-            (OpSpecId::REGOLITH, ForkCondition::Timestamp(0)),
-            (OpSpecId::CANYON, ForkCondition::Timestamp(1_704_992_401)),
-            (OpSpecId::ECOTONE, ForkCondition::Timestamp(1_710_374_401)),
-            (OpSpecId::FJORD, ForkCondition::Timestamp(1_720_627_201)),
-            (OpSpecId::GRANITE, ForkCondition::Timestamp(1_726_070_401)),
-            (OpSpecId::HOLOCENE, ForkCondition::Timestamp(1_736_445_601)),
-            (OpSpecId::ISTHMUS, ForkCondition::Timestamp(1_746_806_401)),
-            (OpSpecId::JOVIAN, ForkCondition::Timestamp(1_764_691_201)),
-        ]
-        .map(|(id, cond)| (id.into(), cond)),
-    ),
+    forks: BTreeMap::from([
+        (OpSpecId::BEDROCK, ForkCondition::Block(0)),
+        (OpSpecId::REGOLITH, ForkCondition::Timestamp(0)),
+        (OpSpecId::CANYON, ForkCondition::Timestamp(1_704_992_401)),
+        (OpSpecId::ECOTONE, ForkCondition::Timestamp(1_710_374_401)),
+        (OpSpecId::FJORD, ForkCondition::Timestamp(1_720_627_201)),
+        (OpSpecId::GRANITE, ForkCondition::Timestamp(1_726_070_401)),
+        (OpSpecId::HOLOCENE, ForkCondition::Timestamp(1_736_445_601)),
+        (OpSpecId::ISTHMUS, ForkCondition::Timestamp(1_746_806_401)),
+        (OpSpecId::JOVIAN, ForkCondition::Timestamp(1_764_691_201)),
+    ]),
 });
 
 /// The Base Sepolia [ChainSpec].
 pub static BASE_SEPOLIA_CHAIN_SPEC: LazyLock<OpChainSpec> = LazyLock::new(|| ChainSpec {
     chain_id: 84532,
-    forks: BTreeMap::from(
-        [
-            (OpSpecId::BEDROCK, ForkCondition::Block(0)),
-            (OpSpecId::REGOLITH, ForkCondition::Timestamp(0)),
-            (OpSpecId::CANYON, ForkCondition::Timestamp(1_699_981_200)),
-            (OpSpecId::ECOTONE, ForkCondition::Timestamp(1_708_534_800)),
-            (OpSpecId::FJORD, ForkCondition::Timestamp(1_716_998_400)),
-            (OpSpecId::GRANITE, ForkCondition::Timestamp(1_723_478_400)),
-            (OpSpecId::HOLOCENE, ForkCondition::Timestamp(1_732_633_200)),
-            (OpSpecId::ISTHMUS, ForkCondition::Timestamp(1_744_905_600)),
-            (OpSpecId::JOVIAN, ForkCondition::Timestamp(1_763_568_001)),
-            // azul
-            (OpSpecId::OSAKA, ForkCondition::Timestamp(1_776_708_000)),
-        ]
-        .map(|(id, cond)| (id.into(), cond)),
-    ),
+    forks: BTreeMap::from([
+        (OpSpecId::BEDROCK, ForkCondition::Block(0)),
+        (OpSpecId::REGOLITH, ForkCondition::Timestamp(0)),
+        (OpSpecId::CANYON, ForkCondition::Timestamp(1_699_981_200)),
+        (OpSpecId::ECOTONE, ForkCondition::Timestamp(1_708_534_800)),
+        (OpSpecId::FJORD, ForkCondition::Timestamp(1_716_998_400)),
+        (OpSpecId::GRANITE, ForkCondition::Timestamp(1_723_478_400)),
+        (OpSpecId::HOLOCENE, ForkCondition::Timestamp(1_732_633_200)),
+        (OpSpecId::ISTHMUS, ForkCondition::Timestamp(1_744_905_600)),
+        (OpSpecId::JOVIAN, ForkCondition::Timestamp(1_763_568_001)),
+        (OpSpecId::AZUL, ForkCondition::Timestamp(1_776_708_000)),
+    ]),
 });
 
 /// [EvmFactory] for Optimism.
@@ -132,7 +124,7 @@ impl EvmFactory for OpEvmFactory {
         <AlloyOpEvmFactory as AlloyEvmFactory>::Error<DBError>;
     type HaltReason = <AlloyOpEvmFactory as AlloyEvmFactory>::HaltReason;
     type Spec = <AlloyOpEvmFactory as AlloyEvmFactory>::Spec;
-    type SpecId = OpEvmSpecId;
+    type SpecId = OpSpecId;
     type Header = OpBlockHeader;
     type Receipt = OpEvmReceipt;
 
@@ -167,7 +159,17 @@ impl EvmFactory for OpEvmFactory {
 
         let block_env = header.to_block_env(spec_id);
 
-        AlloyOpEvmFactory::default().create_evm(db, (cfg_env, block_env).into())
+        if matches!(spec_id, OpSpecId::AZUL) {
+            let inner = Context::op()
+                .with_db(db)
+                .with_block(block_env)
+                .with_cfg(cfg_env)
+                .build_op_with_inspector(NoOpInspector {})
+                .with_precompiles(PrecompilesMap::from_static(azul_precompiles()));
+            alloy_op_evm::OpEvm::new(inner, false)
+        } else {
+            AlloyOpEvmFactory::default().create_evm(db, (cfg_env, block_env).into())
+        }
     }
 }
 
@@ -175,43 +177,7 @@ impl EvmFactory for OpEvmFactory {
 pub type OpCallError = CallError<<OpEvmFactory as EvmFactory>::HaltReason>;
 
 /// [ChainSpec] for Optimism.
-pub type OpChainSpec = ChainSpec<OpEvmSpecId>;
-
-/// [EvmFactory::SpecId] for Optimism.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct OpEvmSpecId(OpSpecId);
-
-impl fmt::Display for OpEvmSpecId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(<&'static str>::from(self.0))
-    }
-}
-
-impl From<OpSpecId> for OpEvmSpecId {
-    fn from(spec: OpSpecId) -> Self {
-        Self(spec)
-    }
-}
-
-impl From<OpEvmSpecId> for OpSpecId {
-    fn from(spec: OpEvmSpecId) -> Self {
-        spec.0
-    }
-}
-impl EvmSpecId for OpEvmSpecId {
-    #[inline]
-    fn has_eip4788(&self) -> bool {
-        self.0 >= OpSpecId::ECOTONE
-    }
-    #[inline]
-    fn has_eip2935(&self) -> bool {
-        self.0 >= OpSpecId::ISTHMUS
-    }
-    #[inline]
-    fn to_u32(&self) -> u32 {
-        self.0 as u32
-    }
-}
+pub type OpChainSpec = ChainSpec<OpSpecId>;
 
 type OpHeader = alloy_consensus::Header;
 
@@ -227,7 +193,7 @@ impl Sealable for OpBlockHeader {
 }
 
 impl EvmBlockHeader for OpBlockHeader {
-    type SpecId = OpEvmSpecId;
+    type SpecId = OpSpecId;
 
     #[inline]
     fn parent_hash(&self) -> &B256 {
@@ -258,7 +224,7 @@ impl EvmBlockHeader for OpBlockHeader {
     fn to_block_env(&self, spec_id: Self::SpecId) -> BlockEnv {
         let header = self.0.inner();
 
-        let eth_spec_id = spec_id.0.into_eth_spec();
+        let eth_spec_id = spec_id.into_eth_spec();
         let blob_excess_gas_and_price =
             header
                 .excess_blob_gas
@@ -275,10 +241,7 @@ impl EvmBlockHeader for OpBlockHeader {
                         excess_blob_gas,
                         eip7691::BLOB_GASPRICE_UPDATE_FRACTION_PECTRA as u64,
                     ),
-                    _ => unimplemented!(
-                        "unsupported spec with `excess_blob_gas`: {}",
-                        <&'static str>::from(spec_id.0)
-                    ),
+                    _ => unimplemented!("unsupported spec with `excess_blob_gas`: {spec_id}"),
                 });
 
         BlockEnv {
@@ -288,7 +251,7 @@ impl EvmBlockHeader for OpBlockHeader {
             gas_limit: header.gas_limit,
             basefee: header.base_fee_per_gas.unwrap_or_default(),
             difficulty: header.difficulty,
-            prevrandao: (spec_id.0 >= OpSpecId::BEDROCK).then_some(header.mix_hash),
+            prevrandao: (spec_id >= OpSpecId::BEDROCK).then_some(header.mix_hash),
             blob_excess_gas_and_price,
             // TODO(https://github.com/boundless-xyz/steel/issues/112): populate from header once alloy supports EIP-7843
             slot_num: 0,
@@ -416,7 +379,7 @@ mod tests {
         fn sepolia_spec_digest() {
             assert_eq!(
                 BASE_SEPOLIA_CHAIN_SPEC.digest(),
-                b256!("0x78c34d7175768c4a9b65941be98eadcd1ed4e3c7ff084b3b8c0f1a5557932003")
+                b256!("0x15e7caa578cb16bd9ec9dc9a01cfb62e5572140dc95d9dec7671346f404f1c22")
             );
         }
     }

--- a/crates/op-steel/src/optimism/mod.rs
+++ b/crates/op-steel/src/optimism/mod.rs
@@ -102,7 +102,22 @@ pub static BASE_MAINNET_CHAIN_SPEC: LazyLock<OpChainSpec> = LazyLock::new(|| Cha
 /// The Base Sepolia [ChainSpec].
 pub static BASE_SEPOLIA_CHAIN_SPEC: LazyLock<OpChainSpec> = LazyLock::new(|| ChainSpec {
     chain_id: 84532,
-    forks: OP_SEPOLIA_CHAIN_SPEC.forks.clone(),
+    forks: BTreeMap::from(
+        [
+            (OpSpecId::BEDROCK, ForkCondition::Block(0)),
+            (OpSpecId::REGOLITH, ForkCondition::Timestamp(0)),
+            (OpSpecId::CANYON, ForkCondition::Timestamp(1_699_981_200)),
+            (OpSpecId::ECOTONE, ForkCondition::Timestamp(1_708_534_800)),
+            (OpSpecId::FJORD, ForkCondition::Timestamp(1_716_998_400)),
+            (OpSpecId::GRANITE, ForkCondition::Timestamp(1_723_478_400)),
+            (OpSpecId::HOLOCENE, ForkCondition::Timestamp(1_732_633_200)),
+            (OpSpecId::ISTHMUS, ForkCondition::Timestamp(1_744_905_600)),
+            (OpSpecId::JOVIAN, ForkCondition::Timestamp(1_763_568_001)),
+            // azul
+            (OpSpecId::OSAKA, ForkCondition::Timestamp(1_776_708_000)),
+        ]
+        .map(|(id, cond)| (id.into(), cond)),
+    ),
 });
 
 /// [EvmFactory] for Optimism.
@@ -401,7 +416,7 @@ mod tests {
         fn sepolia_spec_digest() {
             assert_eq!(
                 BASE_SEPOLIA_CHAIN_SPEC.digest(),
-                b256!("0xa2e376e0229be98aed684c4c52cb9f119f1757ac9d9e5b172a713908f8a3a739")
+                b256!("0x78c34d7175768c4a9b65941be98eadcd1ed4e3c7ff084b3b8c0f1a5557932003")
             );
         }
     }

--- a/crates/op-steel/src/optimism/spec.rs
+++ b/crates/op-steel/src/optimism/spec.rs
@@ -1,0 +1,222 @@
+// Copyright 2026 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Spec-id plumbing for Optimism-family chains.
+//!
+//! Defines [`OpSpecId`], the Optimism/Base hardfork spec used by Steel, along with its
+//! conversion into [`OpRevmSpecId`] (op-revm) and [`SpecId`] (revm), and the Azul
+//! precompile overlay applied by the factory when `AZUL` is active.
+
+use op_revm::{
+    precompiles as op_precompiles,
+    spec::{OpSpecId as OpRevmSpecId, name},
+};
+use risc0_steel::{
+    EvmSpecId,
+    revm::{
+        precompile::{Precompiles, modexp, secp256r1},
+        primitives::hardfork::SpecId,
+    },
+};
+use std::{fmt, sync::OnceLock};
+
+/// [EvmFactory::SpecId](risc0_steel::EvmFactory::SpecId) for Optimism-family chains.
+///
+/// Mirrors op-revm's [`OpRevmSpecId`] with one extra variant: [`OpSpecId::AZUL`], a
+/// Base-specific fork that activates Osaka EVM semantics plus the MODEXP (EIP-7823/7883) and
+/// P256VERIFY (EIP-7951) precompile upgrades. Base treats Azul as a distinct hardfork name
+/// rather than reusing `Osaka`, and Steel follows suit so chain-spec declarations read
+/// naturally and the factory dispatches precompiles off the spec itself rather than chain-id
+/// heuristics.
+///
+/// The upstream `OSAKA` spec is intentionally omitted: OP Stack hasn't ratified an
+/// Osaka-equivalent fork, so the upstream variant has no well-defined semantics for any chain
+/// Steel runs against. Base ships Osaka's EL changes as `AZUL` (with extra precompile rules);
+/// OP chains have not declared one yet.
+///
+/// Discriminant values match [`OpRevmSpecId`] for every shared variant (BEDROCK = 100, …,
+/// INTEROP = 109), so [`ChainSpec`](risc0_steel::config::ChainSpec) digests for OP chains are
+/// unaffected by this rename.
+#[repr(u8)]
+#[derive(Debug, Default, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[allow(non_camel_case_types)]
+pub enum OpSpecId {
+    /// Bedrock.
+    BEDROCK = 100,
+    /// Regolith.
+    REGOLITH,
+    /// Canyon.
+    CANYON,
+    /// Ecotone.
+    ECOTONE,
+    /// Fjord.
+    FJORD,
+    /// Granite.
+    GRANITE,
+    /// Holocene.
+    HOLOCENE,
+    /// Isthmus.
+    ISTHMUS,
+    /// Jovian.
+    #[default]
+    JOVIAN,
+    /// Interop.
+    INTEROP,
+    /// Azul (Base). Osaka EVM + Base-specific MODEXP / P256VERIFY precompile overlay.
+    /// Discriminant skips 110 (which would be upstream `OSAKA`) so Base Sepolia digests are
+    /// stable if an `OSAKA` variant is ever reintroduced.
+    AZUL = 111,
+}
+
+impl OpSpecId {
+    /// Converts into the corresponding revm [`SpecId`]. `AZUL` maps to `OSAKA` since Azul's
+    /// opcode-level semantics are identical to Osaka.
+    #[inline]
+    pub const fn into_eth_spec(self) -> SpecId {
+        match self {
+            Self::AZUL => SpecId::OSAKA,
+            Self::ISTHMUS | Self::JOVIAN | Self::INTEROP => SpecId::PRAGUE,
+            Self::ECOTONE | Self::FJORD | Self::GRANITE | Self::HOLOCENE => SpecId::CANCUN,
+            Self::CANYON => SpecId::SHANGHAI,
+            Self::BEDROCK | Self::REGOLITH => SpecId::MERGE,
+        }
+    }
+}
+
+/// Conversion into op-revm's [`OpRevmSpecId`] for revm-level dispatch. `AZUL` maps to
+/// [`OpRevmSpecId::OSAKA`] — Azul's opcode-level semantics match Osaka; the Base-specific
+/// precompile overlay is applied separately by the factory, which branches on `OpSpecId::AZUL`
+/// before the conversion happens.
+impl From<OpSpecId> for OpRevmSpecId {
+    fn from(spec: OpSpecId) -> Self {
+        match spec {
+            OpSpecId::AZUL => Self::OSAKA,
+            OpSpecId::INTEROP => Self::INTEROP,
+            OpSpecId::JOVIAN => Self::JOVIAN,
+            OpSpecId::ISTHMUS => Self::ISTHMUS,
+            OpSpecId::HOLOCENE => Self::HOLOCENE,
+            OpSpecId::GRANITE => Self::GRANITE,
+            OpSpecId::FJORD => Self::FJORD,
+            OpSpecId::ECOTONE => Self::ECOTONE,
+            OpSpecId::CANYON => Self::CANYON,
+            OpSpecId::REGOLITH => Self::REGOLITH,
+            OpSpecId::BEDROCK => Self::BEDROCK,
+        }
+    }
+}
+
+impl fmt::Display for OpSpecId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::BEDROCK => name::BEDROCK,
+            Self::REGOLITH => name::REGOLITH,
+            Self::CANYON => name::CANYON,
+            Self::ECOTONE => name::ECOTONE,
+            Self::FJORD => name::FJORD,
+            Self::GRANITE => name::GRANITE,
+            Self::HOLOCENE => name::HOLOCENE,
+            Self::ISTHMUS => name::ISTHMUS,
+            Self::JOVIAN => name::JOVIAN,
+            Self::INTEROP => name::INTEROP,
+            Self::AZUL => "Azul",
+        })
+    }
+}
+
+impl EvmSpecId for OpSpecId {
+    #[inline]
+    fn has_eip4788(&self) -> bool {
+        *self >= Self::ECOTONE
+    }
+    #[inline]
+    fn has_eip2935(&self) -> bool {
+        *self >= Self::ISTHMUS
+    }
+    #[inline]
+    fn to_u32(&self) -> u32 {
+        *self as u32
+    }
+}
+
+/// Precompile set for the Base Azul hardfork.
+///
+/// Mirrors `BasePrecompiles::azul()` from `base/base`: op-revm's `jovian()` set plus the
+/// upstream `modexp::OSAKA` (EIP-7823 input cap + EIP-7883 gas) and `secp256r1::P256VERIFY_OSAKA`
+/// (EIP-7951, 6,900 gas) precompiles. op-revm's own `OpRevmSpecId::OSAKA` still resolves to the
+/// `jovian()` set as a placeholder, so Steel applies this overlay itself when `AZUL` is active.
+pub(super) fn azul_precompiles() -> &'static Precompiles {
+    static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
+    INSTANCE.get_or_init(|| {
+        let mut precompiles = op_precompiles::jovian().clone();
+        precompiles.extend([modexp::OSAKA, secp256r1::P256VERIFY_OSAKA]);
+        precompiles
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use risc0_steel::revm::precompile::{PrecompileError, bn254};
+
+    fn encode_length(len: usize) -> [u8; 32] {
+        let mut encoded = [0u8; 32];
+        encoded[24..].copy_from_slice(&(len as u64).to_be_bytes());
+        encoded
+    }
+
+    fn modexp_input(base_len: usize, exp_len: usize, mod_len: usize) -> Vec<u8> {
+        let mut input = Vec::new();
+        input.extend_from_slice(&encode_length(base_len));
+        input.extend_from_slice(&encode_length(exp_len));
+        input.extend_from_slice(&encode_length(mod_len));
+        input.extend(vec![1u8; base_len + exp_len + mod_len]);
+        input
+    }
+
+    #[test]
+    fn azul_spec_conversion() {
+        assert_eq!(OpSpecId::AZUL.into_eth_spec(), SpecId::OSAKA);
+        assert_eq!(OpRevmSpecId::from(OpSpecId::AZUL), OpRevmSpecId::OSAKA);
+    }
+
+    #[test]
+    fn overlay_installs_osaka_precompiles() {
+        let p = azul_precompiles();
+
+        // modexp at 0x05 is the Osaka variant (EIP-7823 rejects fields > 1024 bytes).
+        let modexp = p.get(modexp::OSAKA.address()).unwrap();
+        assert!(matches!(
+            modexp.execute(&modexp_input(1025, 0, 1), u64::MAX),
+            Err(PrecompileError::ModexpEip7823LimitSize)
+        ));
+
+        // p256verify at 0x100 is the Osaka variant (6,900 gas, not Fjord's 3,450).
+        let p256 = p.get(secp256r1::P256VERIFY_OSAKA.address()).unwrap();
+        assert!(matches!(
+            p256.execute(&[], 3_450),
+            Err(PrecompileError::OutOfGas)
+        ));
+    }
+
+    #[test]
+    fn overlay_preserves_jovian_bn254_pair_limit() {
+        // The `extend()` in `azul_precompiles` must not clobber Jovian's bn254-pair override.
+        let pair = azul_precompiles().get(&bn254::pair::ADDRESS).unwrap();
+        let oversized = vec![0u8; op_precompiles::bn254_pair::JOVIAN_MAX_INPUT_SIZE + 1];
+        assert!(matches!(
+            pair.execute(&oversized, u64::MAX),
+            Err(PrecompileError::Bn254PairLength)
+        ));
+    }
+}

--- a/crates/op-steel/tests/op-steel.rs
+++ b/crates/op-steel/tests/op-steel.rs
@@ -22,8 +22,7 @@ use alloy_primitives::{Address, U256, address};
 use risc0_op_steel::{
     Contract,
     config::ChainSpec,
-    op_revm::OpSpecId,
-    optimism::{OpCallError, OpChainSpec, OpEvmEnv, Optimism},
+    optimism::{OpCallError, OpChainSpec, OpEvmEnv, OpSpecId, Optimism},
 };
 use std::{fmt::Debug, sync::LazyLock};
 use test_log::test;
@@ -56,7 +55,7 @@ alloy::sol!(
 );
 
 static OP_ANVIL_CHAIN_SPEC: LazyLock<OpChainSpec> =
-    LazyLock::new(|| ChainSpec::new_single(31337, OpSpecId::ISTHMUS.into()));
+    LazyLock::new(|| ChainSpec::new_single(31337, OpSpecId::ISTHMUS));
 
 /// Returns an Anvil provider with the deployed [Test] contract.
 async fn test_provider() -> impl Provider<Optimism> + Clone {


### PR DESCRIPTION
## Summary

Base Sepolia activates its first Base-specific hardfork, **Azul**, on 2026-04-20 at 18:00 UTC (timestamp `1_776_708_000`). Azul brings Osaka EVM semantics to Base plus Base-specific precompile rules:

- EIP-7825 (per-tx gas cap)
- EIP-7823 (MODEXP input size limit)
- EIP-7883 (MODEXP gas cost increase)
- EIP-7939 (`CLZ` opcode)
- EIP-7951 (P256VERIFY gas doubled to 6,900)

After this timestamp, `BASE_SEPOLIA_CHAIN_SPEC` would otherwise run blocks under Jovian semantics, producing divergent state roots and invalidating every Steel commitment on Base Sepolia.

op-revm's `OpSpecId::OSAKA` still maps to the `jovian()` precompile set as a placeholder — OP Stack hasn't ratified an Osaka-equivalent fork — so Steel installs the MODEXP and P256VERIFY upgrades itself until op-revm catches up.

## Changes

- New `OpSpecId::AZUL` variant in a dedicated `optimism/spec.rs` module, with dispatch conversions into `SpecId::OSAKA` and `op_revm::OpSpecId::OSAKA`.
- `azul_precompiles()` mirrors `base/base`'s `BasePrecompiles::azul()`: `jovian()` extended with `modexp::OSAKA` and `secp256r1::P256VERIFY_OSAKA`. `OpEvmFactory::create_evm` branches on `AZUL` to install the overlay; all other specs delegate to `AlloyOpEvmFactory` unchanged.
- `BASE_SEPOLIA_CHAIN_SPEC` declares Azul at `1_776_708_000`; fork list is inlined now that Base has diverged from OP Sepolia.
- Rename `OpEvmSpecId` → `OpSpecId` and retire the placeholder `OSAKA` variant (no chain activates it — Base goes Jovian → Azul, OP has no Osaka yet). `AZUL = 111` preserves the slot where `OSAKA` sat.

`BASE_MAINNET_CHAIN_SPEC` is intentionally left alone since mainnet Azul (~2026-05-13) is not yet finalized.

## Refs

- [Base Azul spec overview](https://specs.base.org/upgrades/azul/overview)
- [Base v1 upgrade docs](https://docs.base.org/base-chain/node-operators/base-v1-upgrade)