### PR TITLE
WEB3-641: chore: bump alloy/revm/op-alloy stack to consistent set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ### ⚡️ Features
 
 - Add Fusaka support.
-- Add Base Sepolia Azul fork support (activation 2026-04-20 18:00 UTC, timestamp `1_776_708_000`). Mapped to `OpSpecId::KARST` (op-revm 20's Osaka-equivalent OP-Stack fork — same EVM semantics + EIP-7823/7883 MODEXP + EIP-7951 P256VERIFY precompile upgrades that Base ships under the Azul name). Available as `optimism::base::AZUL` for chain-spec readability.
+- Add Base Mainnet (activation 2026-05-21 18:00 UTC, timestamp `1_779_386_400`) and Base Sepolia (activation 2026-04-20 18:00 UTC, timestamp `1_776_708_000`) Azul fork support. Mapped to `OpSpecId::KARST` (op-revm 20's Osaka-equivalent OP-Stack fork — same EVM semantics + EIP-7823/7883 MODEXP + EIP-7951 P256VERIFY precompile upgrades that Base ships under the Azul name). Available as `optimism::base::AZUL` for chain-spec readability.
 - Introduce `EthChainSpec::from_chain_id` and the `define_chain_specs!` macro for efficient, dynamic chain specification lookup. Added `ETH_HOODI_CHAIN_SPEC`.
 - Introduce `Eip2935HistoryCommit` to enable historical state proofs using the EIP-2935 history storage contract. This provides a more direct and efficient alternative to the existing beacon-based `HistoryCommit`.
 - Add a new `precompiles` module with type-safe wrappers for the EIP-2935 `HistoryStorage` and EIP-4788 `BeaconRoots` contracts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ### ⚡️ Features
 
 - Add Fusaka support.
-- Add Base Sepolia Azul fork support (activation 2026-04-20 18:00 UTC, timestamp `1_776_708_000`). A new `OpSpecId::AZUL` variant installs the Osaka MODEXP (EIP-7823/7883) and P256VERIFY (EIP-7951) precompile upgrades on top of op-revm's Jovian set, since `op_revm::OpSpecId::OSAKA` in 17.0 is still a placeholder.
+- Add Base Sepolia Azul fork support (activation 2026-04-20 18:00 UTC, timestamp `1_776_708_000`). Mapped to `OpSpecId::KARST` (op-revm 20's Osaka-equivalent OP-Stack fork — same EVM semantics + EIP-7823/7883 MODEXP + EIP-7951 P256VERIFY precompile upgrades that Base ships under the Azul name). Available as `optimism::base::AZUL` for chain-spec readability.
 - Introduce `EthChainSpec::from_chain_id` and the `define_chain_specs!` macro for efficient, dynamic chain specification lookup. Added `ETH_HOODI_CHAIN_SPEC`.
 - Introduce `Eip2935HistoryCommit` to enable historical state proofs using the EIP-2935 history storage contract. This provides a more direct and efficient alternative to the existing beacon-based `HistoryCommit`.
 - Add a new `precompiles` module with type-safe wrappers for the EIP-2935 `HistoryStorage` and EIP-4788 `BeaconRoots` contracts.
@@ -19,7 +19,7 @@ All notable changes to this project will be documented in this file.
 ### 🚨 Breaking Changes
 
 - **Solidity**: Renamed `CommitmentTooOld` error to `InvalidCommitmentBlockNumber` in `Steel.sol` to better reflect validity checks beyond just age.
-- **`risc0-op-steel`**: Renamed `OpEvmSpecId` → `OpSpecId` (re-exported from `optimism`). The upstream-mirroring `OSAKA` variant has been retired (op-revm 20 has since renamed it to `KARST`) — no chain in the registry activates it. Downstream code should use `OpSpecId::AZUL` for Base chains at or after the Azul fork.
+- **`risc0-op-steel`**: Renamed `OpEvmSpecId` → `OpSpecId`. The enum now mirrors `op_revm::OpSpecId` from op-revm 20 one-to-one (BEDROCK..JOVIAN, KARST, INTEROP); Steel keeps a local copy only because the orphan rule blocks implementing `EvmSpecId` on the foreign type. Downstream code should use `OpSpecId::KARST` (or the `optimism::base::AZUL` alias) for Base chains at or after the Azul fork.
 
 ### 🛠️ Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ### ⚡️ Features
 
 - Add Fusaka support.
-- Add Base Mainnet (activation 2026-05-21 18:00 UTC, timestamp `1_779_386_400`) and Base Sepolia (activation 2026-04-20 18:00 UTC, timestamp `1_776_708_000`) Azul fork support. Mapped to `OpSpecId::KARST` (op-revm 20's Osaka-equivalent OP-Stack fork — same EVM semantics + EIP-7823/7883 MODEXP + EIP-7951 P256VERIFY precompile upgrades that Base ships under the Azul name). Available as `optimism::base::AZUL` for chain-spec readability.
+- Add Base Mainnet (activation 2026-05-21 18:00 UTC, timestamp `1_779_386_400`) and Base Sepolia (activation 2026-04-20 18:00 UTC, timestamp `1_776_708_000`) Azul fork support. Mapped to op-revm 20's `KARST` hardfork (the Osaka-equivalent OP-Stack fork — same EVM semantics + EIP-7823/7883 MODEXP + EIP-7951 P256VERIFY precompile upgrades that Base ships under the Azul name). Available as `optimism::base::AZUL` for chain-spec readability.
 - Introduce `EthChainSpec::from_chain_id` and the `define_chain_specs!` macro for efficient, dynamic chain specification lookup. Added `ETH_HOODI_CHAIN_SPEC`.
 - Introduce `Eip2935HistoryCommit` to enable historical state proofs using the EIP-2935 history storage contract. This provides a more direct and efficient alternative to the existing beacon-based `HistoryCommit`.
 - Add a new `precompiles` module with type-safe wrappers for the EIP-2935 `HistoryStorage` and EIP-4788 `BeaconRoots` contracts.
@@ -19,7 +19,7 @@ All notable changes to this project will be documented in this file.
 ### 🚨 Breaking Changes
 
 - **Solidity**: Renamed `CommitmentTooOld` error to `InvalidCommitmentBlockNumber` in `Steel.sol` to better reflect validity checks beyond just age.
-- **`risc0-op-steel`**: Renamed `OpEvmSpecId` → `OpSpecId`. The enum now mirrors `op_revm::OpSpecId` from op-revm 20 one-to-one (BEDROCK..JOVIAN, KARST, INTEROP); Steel keeps a local copy only because the orphan rule blocks implementing `EvmSpecId` on the foreign type. Downstream code should use `OpSpecId::KARST` (or the `optimism::base::AZUL` alias) for Base chains at or after the Azul fork.
+- **`risc0-op-steel`**: Renamed `OpEvmSpecId` → `OpSpecId`. `OpSpecId` is now a thin newtype around `op_revm::OpSpecId` (re-exported as `OpRevmSpecId`); Steel keeps a local wrapper only because the orphan rule blocks implementing `EvmSpecId` on the foreign type. Downstream code constructs `OpSpecId` values from upstream variants via `OpRevmSpecId::KARST.into()` (or `OpSpecId::new(OpRevmSpecId::KARST)` for const contexts). The `optimism::base::AZUL` alias points at `OpRevmSpecId::KARST` for Base chain specs.
 
 ### 🛠️ Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to this project will be documented in this file.
 ### 🚨 Breaking Changes
 
 - **Solidity**: Renamed `CommitmentTooOld` error to `InvalidCommitmentBlockNumber` in `Steel.sol` to better reflect validity checks beyond just age.
-- **`risc0-op-steel`**: Renamed `OpEvmSpecId` → `OpSpecId` (re-exported from `optimism`). The upstream-mirroring `OSAKA` variant has been retired — no chain in the registry activates it. Downstream code should use `OpSpecId::AZUL` for Base chains at or after the Azul fork.
+- **`risc0-op-steel`**: Renamed `OpEvmSpecId` → `OpSpecId` (re-exported from `optimism`). The upstream-mirroring `OSAKA` variant has been retired (op-revm 20 has since renamed it to `KARST`) — no chain in the registry activates it. Downstream code should use `OpSpecId::AZUL` for Base chains at or after the Azul fork.
 
 ### 🛠️ Fixes
 
@@ -34,7 +34,9 @@ All notable changes to this project will be documented in this file.
 - Improved error messages when the execution block incorrectly matches the commitment block for historical commitments.
 - Re-export `op_revm` from `risc0-op-steel`, so users can access OP-specific revm types (e.g. `OpSpecId`) without adding `op-revm` as a direct dependency.
 - Bumped Rust toolchain to 1.94.
-- Updated dependencies: `alloy-evm` (to 0.30), `alloy-op-evm` (to 0.30), `revm` (to 36.0), `op-revm` (to 17.0), `op-alloy` (to 0.24).
+- Updated dependencies: `alloy` (to 2.0), `alloy-evm` (to 0.33), `alloy-op-evm` (to 0.32), `revm` (to 38.0), `op-revm` (to 20.0), `op-alloy` (to 2.0).
+- Drop the vendored `Optimism` network type in `risc0-op-steel` in favor of `op_alloy_network::Optimism`, now that `op-alloy-network 2.0.0` ships with the upstream `NetworkWallet<Optimism>` conflict fix (closes #116).
+- Populate `BlockEnv::slot_num` from the header's new `slot_number` field (alloy 2.0, EIP-7843) in both `crates/steel/src/ethereum.rs` and `crates/op-steel/src/optimism/mod.rs` (closes #112).
 - Replaced `ethereum-consensus` with `lighthouse-types`, `tree_hash`, and `context_deserialize` for host-side beacon block handling. Affects crates depending on `risc0-steel` with the `host` feature.
 - Removed the `c-kzg` feature from `risc0-steel`'s `revm` dependency. Precompile features (`blst`, `bn`, `c-kzg`) should now be enabled by the guest crate directly.
 - Solidity: updated `forge-std` (to v1.15.0) and `openzeppelin-contracts` (to v5.6.1), moved remappings from `remappings.txt` into `contracts/foundry.toml`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,21 +25,22 @@ risc0-op-steel = { path = "crates/op-steel", default-features = false }
 risc0-steel = { path = "crates/steel", default-features = false }
 
 # Alloy guest dependencies
-alloy-consensus = { version = "1.0" }
-alloy-eips = { version = "1.0" }
-alloy-evm = { version = "0.30" }
+alloy-consensus = { version = "2.0" }
+alloy-eips = { version = "2.0" }
+alloy-evm = { version = "0.33" }
 alloy-rlp = { version = "0.3.8" }
-alloy-primitives = { version = "1.3" }
-alloy-rpc-types = { version = "1.0" }
-alloy-sol-types = { version = "1.3" }
+alloy-primitives = { version = "1.5" }
+alloy-rpc-types = { version = "2.0" }
+alloy-sol-types = { version = "1.5" }
 
 # OP Steel
-alloy-op-evm = { version = "0.30" }
-op-alloy-consensus = { version = "0.24" }
-op-alloy-rpc-types = { version = "0.24" }
+alloy-op-evm = { version = "0.32" }
+op-alloy-consensus = { version = "2.0" }
+op-alloy-network = { version = "2.0" }
+op-alloy-rpc-types = { version = "2.0" }
 
 # Alloy host dependencies
-alloy = { version = "1.0", default-features = false }
+alloy = { version = "2.0", default-features = false }
 alloy-trie = { version = "0.8" }
 
 # Beacon chain support (Lighthouse v8.1.3)
@@ -52,8 +53,8 @@ bincode = { version = "1.3" }
 delegate = "0.13"
 enumn = "0.1"
 log = "0.4"
-revm = { version = "36.0.0", default-features = false, features = ["std"] }
-op-revm = { version = "17.0.0", default-features = false, features = ["std"] }
+revm = { version = "38.0.0", default-features = false, features = ["std"] }
+op-revm = { version = "20.0.0", default-features = false, features = ["std"] }
 serde = "1.0"
 serde_json = "1.0"
 sha2 = { version = "0.10" }

--- a/crates/op-steel/Cargo.toml
+++ b/crates/op-steel/Cargo.toml
@@ -25,6 +25,7 @@ anyhow = { workspace = true }
 delegate = { workspace = true }
 log = { workspace = true }
 op-alloy-consensus = { workspace = true }
+op-alloy-network = { workspace = true, optional = true }
 op-alloy-rpc-types = { workspace = true }
 op-revm = { workspace = true, features = ["serde"] }
 risc0-steel = { workspace = true }
@@ -39,7 +40,7 @@ alloy = { workspace = true, features = ["node-bindings"] }
 
 [features]
 default = []
-host = ["dep:alloy", "dep:tokio", "dep:url", "risc0-steel/host", "alloy-primitives/rand"]
+host = ["dep:alloy", "dep:op-alloy-network", "dep:tokio", "dep:url", "risc0-steel/host", "alloy-primitives/rand"]
 reqwest-native-tls = ["alloy?/reqwest-native-tls", "risc0-steel/reqwest-native-tls"]
 reqwest-rustls-tls = ["alloy?/reqwest-rustls-tls", "risc0-steel/reqwest-rustls-tls"]
 rpc-tests = []

--- a/crates/op-steel/src/optimism/host.rs
+++ b/crates/op-steel/src/optimism/host.rs
@@ -18,18 +18,12 @@ use crate::{
     optimism::{OpBlockHeader, OpChainSpec, OpEvmFactory, OpEvmInput},
 };
 use alloy::{
-    network::{Ethereum, Network, TransactionBuilder},
-    providers::{
-        Provider, ProviderBuilder, RootProvider,
-        fillers::{ChainIdFiller, GasFiller, JoinFill, NonceFiller, RecommendedFillers},
-    },
-    rpc::types::{AccessList, eth as rpc_types},
+    network::Ethereum,
+    providers::{Provider, ProviderBuilder, RootProvider},
 };
-use alloy_consensus::{Header, ReceiptWithBloom, TxType};
-use alloy_primitives::{Address, Bytes, ChainId, Sealable, TxKind, U256};
+use alloy_primitives::{Address, Sealable};
 use anyhow::{Context, Result};
-use op_alloy_consensus::{OpReceipt, OpTxEnvelope, OpTxType, OpTypedTransaction};
-use op_alloy_rpc_types::{OpTransactionReceipt, OpTransactionRequest};
+pub use op_alloy_network::Optimism;
 use risc0_steel::{
     BlockHeaderCommit, Commitment, ComposeInput, EvmEnv, EvmInput,
     host::{
@@ -42,163 +36,6 @@ use std::{
     ops::{Deref, DerefMut},
 };
 use url::Url;
-
-/// TODO(https://github.com/boundless-xyz/steel/issues/116): replace with `op_alloy_network::Optimism`
-/// once a new `op-alloy-network` version is released with the `NetworkWallet` conflict fix.
-///
-/// Types for an OP-stack network.
-#[derive(Clone, Copy, Debug)]
-pub struct Optimism(());
-
-impl Network for Optimism {
-    type TxType = OpTxType;
-    type TxEnvelope = OpTxEnvelope;
-    type UnsignedTx = OpTypedTransaction;
-    type ReceiptEnvelope = ReceiptWithBloom<OpReceipt>;
-    type Header = Header;
-    type TransactionRequest = OpTransactionRequest;
-    type TransactionResponse = op_alloy_rpc_types::Transaction;
-    type ReceiptResponse = OpTransactionReceipt;
-    type HeaderResponse = rpc_types::Header;
-    type BlockResponse = rpc_types::Block<Self::TransactionResponse, Self::HeaderResponse>;
-}
-
-impl TransactionBuilder<Optimism> for OpTransactionRequest {
-    fn chain_id(&self) -> Option<ChainId> {
-        self.as_ref().chain_id()
-    }
-    fn set_chain_id(&mut self, chain_id: ChainId) {
-        self.as_mut().set_chain_id(chain_id);
-    }
-    fn nonce(&self) -> Option<u64> {
-        self.as_ref().nonce()
-    }
-    fn set_nonce(&mut self, nonce: u64) {
-        self.as_mut().set_nonce(nonce);
-    }
-    fn take_nonce(&mut self) -> Option<u64> {
-        self.as_mut().nonce.take()
-    }
-    fn input(&self) -> Option<&Bytes> {
-        self.as_ref().input()
-    }
-    fn set_input<T: Into<Bytes>>(&mut self, input: T) {
-        self.as_mut().set_input(input);
-    }
-    fn from(&self) -> Option<Address> {
-        self.as_ref().from()
-    }
-    fn set_from(&mut self, from: Address) {
-        self.as_mut().set_from(from);
-    }
-    fn kind(&self) -> Option<TxKind> {
-        self.as_ref().kind()
-    }
-    fn clear_kind(&mut self) {
-        self.as_mut().clear_kind();
-    }
-    fn set_kind(&mut self, kind: TxKind) {
-        self.as_mut().set_kind(kind);
-    }
-    fn value(&self) -> Option<U256> {
-        self.as_ref().value()
-    }
-    fn set_value(&mut self, value: U256) {
-        self.as_mut().set_value(value);
-    }
-    fn gas_price(&self) -> Option<u128> {
-        self.as_ref().gas_price()
-    }
-    fn set_gas_price(&mut self, gas_price: u128) {
-        self.as_mut().set_gas_price(gas_price);
-    }
-    fn max_fee_per_gas(&self) -> Option<u128> {
-        self.as_ref().max_fee_per_gas()
-    }
-    fn set_max_fee_per_gas(&mut self, max_fee_per_gas: u128) {
-        self.as_mut().set_max_fee_per_gas(max_fee_per_gas);
-    }
-    fn max_priority_fee_per_gas(&self) -> Option<u128> {
-        self.as_ref().max_priority_fee_per_gas()
-    }
-    fn set_max_priority_fee_per_gas(&mut self, max_priority_fee_per_gas: u128) {
-        self.as_mut()
-            .set_max_priority_fee_per_gas(max_priority_fee_per_gas);
-    }
-    fn gas_limit(&self) -> Option<u64> {
-        self.as_ref().gas_limit()
-    }
-    fn set_gas_limit(&mut self, gas_limit: u64) {
-        self.as_mut().set_gas_limit(gas_limit);
-    }
-    fn access_list(&self) -> Option<&AccessList> {
-        self.as_ref().access_list()
-    }
-    fn set_access_list(&mut self, access_list: AccessList) {
-        self.as_mut().set_access_list(access_list);
-    }
-    fn complete_type(&self, ty: OpTxType) -> Result<(), Vec<&'static str>> {
-        match ty {
-            OpTxType::Deposit => Err(vec!["not implemented for deposit tx"]),
-            _ => {
-                let ty = TxType::try_from(ty as u8).unwrap();
-                self.as_ref().complete_type(ty)
-            }
-        }
-    }
-    fn can_submit(&self) -> bool {
-        self.as_ref().can_submit()
-    }
-    fn can_build(&self) -> bool {
-        self.as_ref().can_build()
-    }
-    fn output_tx_type(&self) -> OpTxType {
-        match self.as_ref().preferred_type() {
-            TxType::Eip1559 | TxType::Eip4844 => OpTxType::Eip1559,
-            TxType::Eip2930 => OpTxType::Eip2930,
-            TxType::Eip7702 => OpTxType::Eip7702,
-            TxType::Legacy => OpTxType::Legacy,
-        }
-    }
-    fn output_tx_type_checked(&self) -> Option<OpTxType> {
-        self.as_ref().buildable_type().map(|tx_ty| match tx_ty {
-            TxType::Eip1559 | TxType::Eip4844 => OpTxType::Eip1559,
-            TxType::Eip2930 => OpTxType::Eip2930,
-            TxType::Eip7702 => OpTxType::Eip7702,
-            TxType::Legacy => OpTxType::Legacy,
-        })
-    }
-    fn prep_for_submission(&mut self) {
-        self.as_mut().prep_for_submission();
-    }
-    fn build_unsigned(self) -> alloy::network::BuildResult<OpTypedTransaction, Optimism> {
-        if let Err((tx_type, missing)) = self.as_ref().missing_keys() {
-            let tx_type = OpTxType::try_from(tx_type as u8).unwrap();
-            return Err(
-                alloy::network::TransactionBuilderError::InvalidTransactionRequest(
-                    tx_type, missing,
-                )
-                .into_unbuilt(self),
-            );
-        }
-        Ok(self.build_typed_tx().expect("checked by missing_keys"))
-    }
-    async fn build<W: alloy::network::NetworkWallet<Optimism>>(
-        self,
-        wallet: &W,
-    ) -> Result<<Optimism as Network>::TxEnvelope, alloy::network::TransactionBuilderError<Optimism>>
-    {
-        Ok(wallet.sign_request(self).await?)
-    }
-}
-
-impl RecommendedFillers for Optimism {
-    type RecommendedFillers = JoinFill<GasFiller, JoinFill<NonceFiller, ChainIdFiller>>;
-
-    fn recommended_fillers() -> Self::RecommendedFillers {
-        Default::default()
-    }
-}
 
 /// Wrapped [EvmEnv] for Optimism.
 pub struct OpEvmEnv<D, C> {

--- a/crates/op-steel/src/optimism/mod.rs
+++ b/crates/op-steel/src/optimism/mod.rs
@@ -45,11 +45,9 @@ mod host;
 #[cfg(feature = "host")]
 pub use host::*;
 
-/// Lifts an array of `(OpRevmSpecId, FC)` chain-spec entries into the `(OpSpecId, FC)`
-/// form `ChainSpec` expects. Lets chain-spec literals stay one line per fork without
-/// scattering `.into()` calls across each entry.
+/// Lifts an array of `OpRevmSpecId` entries into the `OpSpecId` form `ChainSpec` expects.
 fn forks<const N: usize>(entries: [(OpRevmSpecId, FC); N]) -> [(OpSpecId, FC); N] {
-    entries.map(|(spec, cond)| (spec.into(), cond))
+    entries.map(|(spec, cond)| (OpSpecId::new(spec), cond))
 }
 
 /// The OP Mainnet [ChainSpec].

--- a/crates/op-steel/src/optimism/mod.rs
+++ b/crates/op-steel/src/optimism/mod.rs
@@ -37,7 +37,7 @@ use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, error::Error, sync::LazyLock};
 
 mod spec;
-pub use spec::{OpSpecId, base};
+pub use spec::{OpRevmSpecId, OpSpecId, base};
 
 #[cfg(feature = "host")]
 mod host;

--- a/crates/op-steel/src/optimism/mod.rs
+++ b/crates/op-steel/src/optimism/mod.rs
@@ -16,17 +16,17 @@ use crate::game::DisputeGameInput;
 use alloy_consensus::{Eip658Value, ReceiptWithBloom, TxReceipt};
 use alloy_eips::{Encodable2718, Typed2718, eip4844, eip7691};
 use alloy_evm::{Database, EvmFactory as AlloyEvmFactory, precompiles::PrecompilesMap};
-use alloy_op_evm::OpEvmFactory as AlloyOpEvmFactory;
+use alloy_op_evm::{OpEvmFactory as AlloyOpEvmFactory, OpTx};
 use alloy_primitives::{Address, B256, BlockNumber, Bloom, Bytes, ChainId, Sealable, TxKind, U256};
 use alloy_rlp::BufMut;
 use delegate::delegate;
 use op_alloy_consensus::OpReceipt;
-use op_revm::{DefaultOp, OpBuilder, OpTransaction};
+use op_revm::{L1BlockInfo, OpBuilder, OpTransaction};
 use risc0_steel::{
     BlockInput, CallError, Commitment, EvmBlockHeader, EvmEnv, EvmFactory, StateDb,
     config::{ChainSpec, ForkCondition},
     revm::{
-        Context,
+        Context, MainContext,
         context::{BlockEnv, CfgEnv, TxEnv},
         context_interface::block::BlobExcessGasAndPrice,
         inspector::NoOpInspector,
@@ -129,7 +129,7 @@ impl EvmFactory for OpEvmFactory {
     type Receipt = OpEvmReceipt;
 
     fn new_tx(address: Address, data: Bytes) -> Self::Tx {
-        alloy_op_evm::OpTx(OpTransaction {
+        OpTx(OpTransaction {
             base: TxEnv {
                 caller: address,
                 kind: TxKind::Call(address),
@@ -160,7 +160,10 @@ impl EvmFactory for OpEvmFactory {
         let block_env = header.to_block_env(spec_id);
 
         if matches!(spec_id, OpSpecId::AZUL) {
-            let inner = Context::op()
+            let inner = Context::mainnet()
+                .with_tx(OpTx(OpTransaction::builder().build_fill()))
+                .with_cfg(CfgEnv::new_with_spec(op_revm::OpSpecId::BEDROCK))
+                .with_chain(L1BlockInfo::default())
                 .with_db(db)
                 .with_block(block_env)
                 .with_cfg(cfg_env)
@@ -253,8 +256,7 @@ impl EvmBlockHeader for OpBlockHeader {
             difficulty: header.difficulty,
             prevrandao: (spec_id >= OpSpecId::BEDROCK).then_some(header.mix_hash),
             blob_excess_gas_and_price,
-            // TODO(https://github.com/boundless-xyz/steel/issues/112): populate from header once alloy supports EIP-7843
-            slot_num: 0,
+            slot_num: header.slot_number.unwrap_or_default(),
         }
     }
 }

--- a/crates/op-steel/src/optimism/mod.rs
+++ b/crates/op-steel/src/optimism/mod.rs
@@ -24,7 +24,7 @@ use op_alloy_consensus::OpReceipt;
 use op_revm::OpTransaction;
 use risc0_steel::{
     BlockInput, CallError, Commitment, EvmBlockHeader, EvmEnv, EvmFactory, StateDb,
-    config::{ChainSpec, ForkCondition},
+    config::{ChainSpec, ForkCondition as FC},
     revm::{
         context::{BlockEnv, CfgEnv, TxEnv},
         context_interface::block::BlobExcessGasAndPrice,
@@ -45,74 +45,81 @@ mod host;
 #[cfg(feature = "host")]
 pub use host::*;
 
+/// Lifts an array of `(OpRevmSpecId, FC)` chain-spec entries into the `(OpSpecId, FC)`
+/// form `ChainSpec` expects. Lets chain-spec literals stay one line per fork without
+/// scattering `.into()` calls across each entry.
+fn forks<const N: usize>(entries: [(OpRevmSpecId, FC); N]) -> [(OpSpecId, FC); N] {
+    entries.map(|(spec, cond)| (spec.into(), cond))
+}
+
 /// The OP Mainnet [ChainSpec].
 pub static OP_MAINNET_CHAIN_SPEC: LazyLock<OpChainSpec> = LazyLock::new(|| ChainSpec {
     chain_id: 10,
-    forks: BTreeMap::from([
-        (OpSpecId::BEDROCK, ForkCondition::Block(105_235_063)),
-        (OpSpecId::REGOLITH, ForkCondition::Timestamp(0)),
-        (OpSpecId::CANYON, ForkCondition::Timestamp(1_704_992_401)),
-        (OpSpecId::ECOTONE, ForkCondition::Timestamp(1_710_374_401)),
-        (OpSpecId::FJORD, ForkCondition::Timestamp(1_720_627_201)),
-        (OpSpecId::GRANITE, ForkCondition::Timestamp(1_726_070_401)),
-        (OpSpecId::HOLOCENE, ForkCondition::Timestamp(1_736_445_601)),
-        (OpSpecId::ISTHMUS, ForkCondition::Timestamp(1_746_806_401)),
-        (OpSpecId::JOVIAN, ForkCondition::Timestamp(1_764_691_201)),
-    ]),
+    forks: BTreeMap::from(forks([
+        (OpRevmSpecId::BEDROCK, FC::Block(105_235_063)),
+        (OpRevmSpecId::REGOLITH, FC::Timestamp(0)),
+        (OpRevmSpecId::CANYON, FC::Timestamp(1_704_992_401)),
+        (OpRevmSpecId::ECOTONE, FC::Timestamp(1_710_374_401)),
+        (OpRevmSpecId::FJORD, FC::Timestamp(1_720_627_201)),
+        (OpRevmSpecId::GRANITE, FC::Timestamp(1_726_070_401)),
+        (OpRevmSpecId::HOLOCENE, FC::Timestamp(1_736_445_601)),
+        (OpRevmSpecId::ISTHMUS, FC::Timestamp(1_746_806_401)),
+        (OpRevmSpecId::JOVIAN, FC::Timestamp(1_764_691_201)),
+    ])),
 });
 
 /// The OP Sepolia [ChainSpec].
 pub static OP_SEPOLIA_CHAIN_SPEC: LazyLock<OpChainSpec> = LazyLock::new(|| ChainSpec {
     chain_id: 11155420,
-    forks: BTreeMap::from([
-        (OpSpecId::BEDROCK, ForkCondition::Block(0)),
-        (OpSpecId::REGOLITH, ForkCondition::Timestamp(0)),
-        (OpSpecId::CANYON, ForkCondition::Timestamp(1_699_981_200)),
-        (OpSpecId::ECOTONE, ForkCondition::Timestamp(1_708_534_800)),
-        (OpSpecId::FJORD, ForkCondition::Timestamp(1_716_998_400)),
-        (OpSpecId::GRANITE, ForkCondition::Timestamp(1_723_478_400)),
-        (OpSpecId::HOLOCENE, ForkCondition::Timestamp(1_732_633_200)),
-        (OpSpecId::ISTHMUS, ForkCondition::Timestamp(1_744_905_600)),
-        (OpSpecId::JOVIAN, ForkCondition::Timestamp(1_763_568_001)),
-    ]),
+    forks: BTreeMap::from(forks([
+        (OpRevmSpecId::BEDROCK, FC::Block(0)),
+        (OpRevmSpecId::REGOLITH, FC::Timestamp(0)),
+        (OpRevmSpecId::CANYON, FC::Timestamp(1_699_981_200)),
+        (OpRevmSpecId::ECOTONE, FC::Timestamp(1_708_534_800)),
+        (OpRevmSpecId::FJORD, FC::Timestamp(1_716_998_400)),
+        (OpRevmSpecId::GRANITE, FC::Timestamp(1_723_478_400)),
+        (OpRevmSpecId::HOLOCENE, FC::Timestamp(1_732_633_200)),
+        (OpRevmSpecId::ISTHMUS, FC::Timestamp(1_744_905_600)),
+        (OpRevmSpecId::JOVIAN, FC::Timestamp(1_763_568_001)),
+    ])),
 });
 
 /// The Base Mainnet [ChainSpec].
 pub static BASE_MAINNET_CHAIN_SPEC: LazyLock<OpChainSpec> = LazyLock::new(|| ChainSpec {
     chain_id: 8453,
-    forks: BTreeMap::from([
-        (OpSpecId::BEDROCK, ForkCondition::Block(0)),
-        (OpSpecId::REGOLITH, ForkCondition::Timestamp(0)),
-        (OpSpecId::CANYON, ForkCondition::Timestamp(1_704_992_401)),
-        (OpSpecId::ECOTONE, ForkCondition::Timestamp(1_710_374_401)),
-        (OpSpecId::FJORD, ForkCondition::Timestamp(1_720_627_201)),
-        (OpSpecId::GRANITE, ForkCondition::Timestamp(1_726_070_401)),
-        (OpSpecId::HOLOCENE, ForkCondition::Timestamp(1_736_445_601)),
-        (OpSpecId::ISTHMUS, ForkCondition::Timestamp(1_746_806_401)),
-        (OpSpecId::JOVIAN, ForkCondition::Timestamp(1_764_691_201)),
+    forks: BTreeMap::from(forks([
+        (OpRevmSpecId::BEDROCK, FC::Block(0)),
+        (OpRevmSpecId::REGOLITH, FC::Timestamp(0)),
+        (OpRevmSpecId::CANYON, FC::Timestamp(1_704_992_401)),
+        (OpRevmSpecId::ECOTONE, FC::Timestamp(1_710_374_401)),
+        (OpRevmSpecId::FJORD, FC::Timestamp(1_720_627_201)),
+        (OpRevmSpecId::GRANITE, FC::Timestamp(1_726_070_401)),
+        (OpRevmSpecId::HOLOCENE, FC::Timestamp(1_736_445_601)),
+        (OpRevmSpecId::ISTHMUS, FC::Timestamp(1_746_806_401)),
+        (OpRevmSpecId::JOVIAN, FC::Timestamp(1_764_691_201)),
         // Base names this fork "Azul"; EVM-level it's the Karst-equivalent
         // (Osaka EVM + EIP-7823/7883 MODEXP + EIP-7951 P256VERIFY).
-        (base::AZUL, ForkCondition::Timestamp(1_779_386_400)),
-    ]),
+        (base::AZUL, FC::Timestamp(1_779_386_400)),
+    ])),
 });
 
 /// The Base Sepolia [ChainSpec].
 pub static BASE_SEPOLIA_CHAIN_SPEC: LazyLock<OpChainSpec> = LazyLock::new(|| ChainSpec {
     chain_id: 84532,
-    forks: BTreeMap::from([
-        (OpSpecId::BEDROCK, ForkCondition::Block(0)),
-        (OpSpecId::REGOLITH, ForkCondition::Timestamp(0)),
-        (OpSpecId::CANYON, ForkCondition::Timestamp(1_699_981_200)),
-        (OpSpecId::ECOTONE, ForkCondition::Timestamp(1_708_534_800)),
-        (OpSpecId::FJORD, ForkCondition::Timestamp(1_716_998_400)),
-        (OpSpecId::GRANITE, ForkCondition::Timestamp(1_723_478_400)),
-        (OpSpecId::HOLOCENE, ForkCondition::Timestamp(1_732_633_200)),
-        (OpSpecId::ISTHMUS, ForkCondition::Timestamp(1_744_905_600)),
-        (OpSpecId::JOVIAN, ForkCondition::Timestamp(1_763_568_001)),
+    forks: BTreeMap::from(forks([
+        (OpRevmSpecId::BEDROCK, FC::Block(0)),
+        (OpRevmSpecId::REGOLITH, FC::Timestamp(0)),
+        (OpRevmSpecId::CANYON, FC::Timestamp(1_699_981_200)),
+        (OpRevmSpecId::ECOTONE, FC::Timestamp(1_708_534_800)),
+        (OpRevmSpecId::FJORD, FC::Timestamp(1_716_998_400)),
+        (OpRevmSpecId::GRANITE, FC::Timestamp(1_723_478_400)),
+        (OpRevmSpecId::HOLOCENE, FC::Timestamp(1_732_633_200)),
+        (OpRevmSpecId::ISTHMUS, FC::Timestamp(1_744_905_600)),
+        (OpRevmSpecId::JOVIAN, FC::Timestamp(1_763_568_001)),
         // Base names this fork "Azul"; EVM-level it's the Karst-equivalent
         // (Osaka EVM + EIP-7823/7883 MODEXP + EIP-7951 P256VERIFY).
-        (base::AZUL, ForkCondition::Timestamp(1_776_708_000)),
-    ]),
+        (base::AZUL, FC::Timestamp(1_776_708_000)),
+    ])),
 });
 
 /// [EvmFactory] for Optimism.
@@ -244,7 +251,7 @@ impl EvmBlockHeader for OpBlockHeader {
             gas_limit: header.gas_limit,
             basefee: header.base_fee_per_gas.unwrap_or_default(),
             difficulty: header.difficulty,
-            prevrandao: (spec_id >= OpSpecId::BEDROCK).then_some(header.mix_hash),
+            prevrandao: (spec_id.into_inner() >= OpRevmSpecId::BEDROCK).then_some(header.mix_hash),
             blob_excess_gas_and_price,
             slot_num: header.slot_number.unwrap_or_default(),
         }

--- a/crates/op-steel/src/optimism/mod.rs
+++ b/crates/op-steel/src/optimism/mod.rs
@@ -21,12 +21,11 @@ use alloy_primitives::{Address, B256, BlockNumber, Bloom, Bytes, ChainId, Sealab
 use alloy_rlp::BufMut;
 use delegate::delegate;
 use op_alloy_consensus::OpReceipt;
-use op_revm::{L1BlockInfo, OpBuilder, OpTransaction};
+use op_revm::OpTransaction;
 use risc0_steel::{
     BlockInput, CallError, Commitment, EvmBlockHeader, EvmEnv, EvmFactory, StateDb,
     config::{ChainSpec, ForkCondition},
     revm::{
-        Context, MainContext,
         context::{BlockEnv, CfgEnv, TxEnv},
         context_interface::block::BlobExcessGasAndPrice,
         inspector::NoOpInspector,
@@ -159,19 +158,14 @@ impl EvmFactory for OpEvmFactory {
 
         let block_env = header.to_block_env(spec_id);
 
+        let evm = AlloyOpEvmFactory::default().create_evm(db, (cfg_env, block_env).into());
         if matches!(spec_id, OpSpecId::AZUL) {
-            let inner = Context::mainnet()
-                .with_tx(OpTx(OpTransaction::builder().build_fill()))
-                .with_cfg(CfgEnv::new_with_spec(op_revm::OpSpecId::BEDROCK))
-                .with_chain(L1BlockInfo::default())
-                .with_db(db)
-                .with_block(block_env)
-                .with_cfg(cfg_env)
-                .build_op_with_inspector(NoOpInspector {})
+            let inner = evm
+                .into_inner()
                 .with_precompiles(PrecompilesMap::from_static(azul_precompiles()));
             alloy_op_evm::OpEvm::new(inner, false)
         } else {
-            AlloyOpEvmFactory::default().create_evm(db, (cfg_env, block_env).into())
+            evm
         }
     }
 }

--- a/crates/op-steel/src/optimism/mod.rs
+++ b/crates/op-steel/src/optimism/mod.rs
@@ -15,7 +15,7 @@
 use crate::game::DisputeGameInput;
 use alloy_consensus::{Eip658Value, ReceiptWithBloom, TxReceipt};
 use alloy_eips::{Encodable2718, Typed2718, eip4844, eip7691};
-use alloy_evm::{Database, EvmFactory as AlloyEvmFactory, precompiles::PrecompilesMap};
+use alloy_evm::{Database, EvmFactory as AlloyEvmFactory};
 use alloy_op_evm::{OpEvmFactory as AlloyOpEvmFactory, OpTx};
 use alloy_primitives::{Address, B256, BlockNumber, Bloom, Bytes, ChainId, Sealable, TxKind, U256};
 use alloy_rlp::BufMut;
@@ -37,8 +37,7 @@ use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, error::Error, sync::LazyLock};
 
 mod spec;
-pub use spec::OpSpecId;
-use spec::azul_precompiles;
+pub use spec::{OpSpecId, base};
 
 #[cfg(feature = "host")]
 mod host;
@@ -107,7 +106,9 @@ pub static BASE_SEPOLIA_CHAIN_SPEC: LazyLock<OpChainSpec> = LazyLock::new(|| Cha
         (OpSpecId::HOLOCENE, ForkCondition::Timestamp(1_732_633_200)),
         (OpSpecId::ISTHMUS, ForkCondition::Timestamp(1_744_905_600)),
         (OpSpecId::JOVIAN, ForkCondition::Timestamp(1_763_568_001)),
-        (OpSpecId::AZUL, ForkCondition::Timestamp(1_776_708_000)),
+        // Base names this fork "Azul"; EVM-level it's the Karst-equivalent
+        // (Osaka EVM + EIP-7823/7883 MODEXP + EIP-7951 P256VERIFY).
+        (base::AZUL, ForkCondition::Timestamp(1_776_708_000)),
     ]),
 });
 
@@ -158,15 +159,7 @@ impl EvmFactory for OpEvmFactory {
 
         let block_env = header.to_block_env(spec_id);
 
-        let evm = AlloyOpEvmFactory::default().create_evm(db, (cfg_env, block_env).into());
-        if matches!(spec_id, OpSpecId::AZUL) {
-            let inner = evm
-                .into_inner()
-                .with_precompiles(PrecompilesMap::from_static(azul_precompiles()));
-            alloy_op_evm::OpEvm::new(inner, false)
-        } else {
-            evm
-        }
+        AlloyOpEvmFactory::default().create_evm(db, (cfg_env, block_env).into())
     }
 }
 
@@ -375,7 +368,7 @@ mod tests {
         fn sepolia_spec_digest() {
             assert_eq!(
                 BASE_SEPOLIA_CHAIN_SPEC.digest(),
-                b256!("0x15e7caa578cb16bd9ec9dc9a01cfb62e5572140dc95d9dec7671346f404f1c22")
+                b256!("0x3519660d6ecbd34367740f5ca18449cba8b389594f69f177bbf21c46e505c61e")
             );
         }
     }

--- a/crates/op-steel/src/optimism/mod.rs
+++ b/crates/op-steel/src/optimism/mod.rs
@@ -90,6 +90,9 @@ pub static BASE_MAINNET_CHAIN_SPEC: LazyLock<OpChainSpec> = LazyLock::new(|| Cha
         (OpSpecId::HOLOCENE, ForkCondition::Timestamp(1_736_445_601)),
         (OpSpecId::ISTHMUS, ForkCondition::Timestamp(1_746_806_401)),
         (OpSpecId::JOVIAN, ForkCondition::Timestamp(1_764_691_201)),
+        // Base names this fork "Azul"; EVM-level it's the Karst-equivalent
+        // (Osaka EVM + EIP-7823/7883 MODEXP + EIP-7951 P256VERIFY).
+        (base::AZUL, ForkCondition::Timestamp(1_779_386_400)),
     ]),
 });
 
@@ -360,7 +363,7 @@ mod tests {
         fn mainnet_spec_digest() {
             assert_eq!(
                 BASE_MAINNET_CHAIN_SPEC.digest(),
-                b256!("0xde0027ffd04b70b50fb52de9d6738b0dc66c1d84654ca3889b57f790979f6905")
+                b256!("0xd16332d74ced8e4fa1cc0810be6d01ea607018745cba80c230a4b79498c513ef")
             );
         }
 

--- a/crates/op-steel/src/optimism/spec.rs
+++ b/crates/op-steel/src/optimism/spec.rs
@@ -36,18 +36,19 @@ use std::{fmt, sync::OnceLock};
 /// Mirrors op-revm's [`OpRevmSpecId`] with one extra variant: [`OpSpecId::AZUL`], a
 /// Base-specific fork that activates Osaka EVM semantics plus the MODEXP (EIP-7823/7883) and
 /// P256VERIFY (EIP-7951) precompile upgrades. Base treats Azul as a distinct hardfork name
-/// rather than reusing `Osaka`, and Steel follows suit so chain-spec declarations read
+/// rather than reusing `Karst`, and Steel follows suit so chain-spec declarations read
 /// naturally and the factory dispatches precompiles off the spec itself rather than chain-id
 /// heuristics.
 ///
-/// The upstream `OSAKA` spec is intentionally omitted: OP Stack hasn't ratified an
-/// Osaka-equivalent fork, so the upstream variant has no well-defined semantics for any chain
-/// Steel runs against. Base ships Osaka's EL changes as `AZUL` (with extra precompile rules);
-/// OP chains have not declared one yet.
+/// The upstream `KARST` spec (op-revm's Osaka-equivalent fork name) is intentionally omitted:
+/// OP Stack hasn't ratified Karst for any chain Steel runs against, so the upstream variant
+/// has no well-defined semantics here. Base ships Osaka's EL changes as `AZUL` (with extra
+/// precompile rules); OP chains have not declared one yet.
 ///
-/// Discriminant values match [`OpRevmSpecId`] for every shared variant (BEDROCK = 100, …,
-/// INTEROP = 109), so [`ChainSpec`](risc0_steel::config::ChainSpec) digests for OP chains are
-/// unaffected by this rename.
+/// Discriminant values match [`OpRevmSpecId`] for every shared variant up to `JOVIAN` (108).
+/// `INTEROP` keeps Steel's original 109 (op-revm 20 shifted it to 110 when it inserted KARST
+/// at 109), and `AZUL` is pinned at 111 so [`ChainSpec`](risc0_steel::config::ChainSpec)
+/// digests for OP and Base chains are unchanged across the op-revm 17→20 bump.
 #[repr(u8)]
 #[derive(Debug, Default, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[allow(non_camel_case_types)]
@@ -95,13 +96,13 @@ impl OpSpecId {
 }
 
 /// Conversion into op-revm's [`OpRevmSpecId`] for revm-level dispatch. `AZUL` maps to
-/// [`OpRevmSpecId::OSAKA`] — Azul's opcode-level semantics match Osaka; the Base-specific
-/// precompile overlay is applied separately by the factory, which branches on `OpSpecId::AZUL`
-/// before the conversion happens.
+/// [`OpRevmSpecId::KARST`] — Azul's opcode-level semantics match Karst (op-revm 20's rename
+/// of the former `OSAKA` variant); the Base-specific precompile overlay is applied separately
+/// by the factory, which branches on `OpSpecId::AZUL` before the conversion happens.
 impl From<OpSpecId> for OpRevmSpecId {
     fn from(spec: OpSpecId) -> Self {
         match spec {
-            OpSpecId::AZUL => Self::OSAKA,
+            OpSpecId::AZUL => Self::KARST,
             OpSpecId::INTEROP => Self::INTEROP,
             OpSpecId::JOVIAN => Self::JOVIAN,
             OpSpecId::ISTHMUS => Self::ISTHMUS,
@@ -153,7 +154,7 @@ impl EvmSpecId for OpSpecId {
 ///
 /// Mirrors `BasePrecompiles::azul()` from `base/base`: op-revm's `jovian()` set plus the
 /// upstream `modexp::OSAKA` (EIP-7823 input cap + EIP-7883 gas) and `secp256r1::P256VERIFY_OSAKA`
-/// (EIP-7951, 6,900 gas) precompiles. op-revm's own `OpRevmSpecId::OSAKA` still resolves to the
+/// (EIP-7951, 6,900 gas) precompiles. op-revm's own `OpRevmSpecId::KARST` still resolves to the
 /// `jovian()` set as a placeholder, so Steel applies this overlay itself when `AZUL` is active.
 pub(super) fn azul_precompiles() -> &'static Precompiles {
     static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
@@ -167,7 +168,7 @@ pub(super) fn azul_precompiles() -> &'static Precompiles {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use risc0_steel::revm::precompile::{PrecompileError, bn254};
+    use risc0_steel::revm::precompile::{PrecompileHalt, bn254};
 
     fn encode_length(len: usize) -> [u8; 32] {
         let mut encoded = [0u8; 32];
@@ -187,7 +188,7 @@ mod tests {
     #[test]
     fn azul_spec_conversion() {
         assert_eq!(OpSpecId::AZUL.into_eth_spec(), SpecId::OSAKA);
-        assert_eq!(OpRevmSpecId::from(OpSpecId::AZUL), OpRevmSpecId::OSAKA);
+        assert_eq!(OpRevmSpecId::from(OpSpecId::AZUL), OpRevmSpecId::KARST);
     }
 
     #[test]
@@ -196,17 +197,18 @@ mod tests {
 
         // modexp at 0x05 is the Osaka variant (EIP-7823 rejects fields > 1024 bytes).
         let modexp = p.get(modexp::OSAKA.address()).unwrap();
-        assert!(matches!(
-            modexp.execute(&modexp_input(1025, 0, 1), u64::MAX),
-            Err(PrecompileError::ModexpEip7823LimitSize)
-        ));
+        let out = modexp
+            .execute(&modexp_input(1025, 0, 1), u64::MAX, 0)
+            .unwrap();
+        assert_eq!(
+            out.halt_reason(),
+            Some(&PrecompileHalt::ModexpEip7823LimitSize)
+        );
 
         // p256verify at 0x100 is the Osaka variant (6,900 gas, not Fjord's 3,450).
         let p256 = p.get(secp256r1::P256VERIFY_OSAKA.address()).unwrap();
-        assert!(matches!(
-            p256.execute(&[], 3_450),
-            Err(PrecompileError::OutOfGas)
-        ));
+        let out = p256.execute(&[], 3_450, 0).unwrap();
+        assert_eq!(out.halt_reason(), Some(&PrecompileHalt::OutOfGas));
     }
 
     #[test]
@@ -214,9 +216,7 @@ mod tests {
         // The `extend()` in `azul_precompiles` must not clobber Jovian's bn254-pair override.
         let pair = azul_precompiles().get(&bn254::pair::ADDRESS).unwrap();
         let oversized = vec![0u8; op_precompiles::bn254_pair::JOVIAN_MAX_INPUT_SIZE + 1];
-        assert!(matches!(
-            pair.execute(&oversized, u64::MAX),
-            Err(PrecompileError::Bn254PairLength)
-        ));
+        let out = pair.execute(&oversized, u64::MAX, 0).unwrap();
+        assert_eq!(out.halt_reason(), Some(&PrecompileHalt::Bn254PairLength));
     }
 }

--- a/crates/op-steel/src/optimism/spec.rs
+++ b/crates/op-steel/src/optimism/spec.rs
@@ -14,41 +14,24 @@
 
 //! Spec-id plumbing for Optimism-family chains.
 //!
-//! Defines [`OpSpecId`], the Optimism/Base hardfork spec used by Steel, along with its
-//! conversion into [`OpRevmSpecId`] (op-revm) and [`SpecId`] (revm), and the Azul
-//! precompile overlay applied by the factory when `AZUL` is active.
+//! Defines [`OpSpecId`], the Optimism/Base hardfork spec used by Steel. The enum mirrors
+//! op-revm's [`OpRevmSpecId`] one-to-one — it exists locally only so [`EvmSpecId`] can be
+//! implemented on it (orphan rule blocks the impl on `op_revm::OpSpecId` from this crate).
 
-use op_revm::{
-    precompiles as op_precompiles,
-    spec::{OpSpecId as OpRevmSpecId, name},
-};
-use risc0_steel::{
-    EvmSpecId,
-    revm::{
-        precompile::{Precompiles, modexp, secp256r1},
-        primitives::hardfork::SpecId,
-    },
-};
-use std::{fmt, sync::OnceLock};
+use op_revm::spec::{OpSpecId as OpRevmSpecId, name};
+use risc0_steel::{EvmSpecId, revm::primitives::hardfork::SpecId};
+use std::fmt;
 
 /// [EvmFactory::SpecId](risc0_steel::EvmFactory::SpecId) for Optimism-family chains.
 ///
-/// Mirrors op-revm's [`OpRevmSpecId`] with one extra variant: [`OpSpecId::AZUL`], a
-/// Base-specific fork that activates Osaka EVM semantics plus the MODEXP (EIP-7823/7883) and
-/// P256VERIFY (EIP-7951) precompile upgrades. Base treats Azul as a distinct hardfork name
-/// rather than reusing `Karst`, and Steel follows suit so chain-spec declarations read
-/// naturally and the factory dispatches precompiles off the spec itself rather than chain-id
-/// heuristics.
+/// Mirrors [`OpRevmSpecId`] from op-revm 20: variants and discriminants are identical, and
+/// [`From<OpSpecId>`] for both [`OpRevmSpecId`] and [`SpecId`] are pure passthroughs to the
+/// upstream conversions. Steel maintains its own copy only because [`EvmSpecId`] is defined
+/// here and the orphan rule blocks implementing it directly on [`OpRevmSpecId`].
 ///
-/// The upstream `KARST` spec (op-revm's Osaka-equivalent fork name) is intentionally omitted:
-/// OP Stack hasn't ratified Karst for any chain Steel runs against, so the upstream variant
-/// has no well-defined semantics here. Base ships Osaka's EL changes as `AZUL` (with extra
-/// precompile rules); OP chains have not declared one yet.
-///
-/// Discriminant values match [`OpRevmSpecId`] for every shared variant up to `JOVIAN` (108).
-/// `INTEROP` keeps Steel's original 109 (op-revm 20 shifted it to 110 when it inserted KARST
-/// at 109), and `AZUL` is pinned at 111 so [`ChainSpec`](risc0_steel::config::ChainSpec)
-/// digests for OP and Base chains are unchanged across the op-revm 17→20 bump.
+/// Base's "Azul" hardfork is the same as upstream `Karst` at the EVM/precompile level
+/// (Osaka EVM + EIP-7823/7883 MODEXP + EIP-7951 P256VERIFY); see [`base::AZUL`] for a
+/// chain-spec-friendly alias.
 #[repr(u8)]
 #[derive(Debug, Default, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[allow(non_camel_case_types)]
@@ -72,48 +55,42 @@ pub enum OpSpecId {
     /// Jovian.
     #[default]
     JOVIAN,
+    /// Karst (Osaka EVM + EIP-7823/7883 MODEXP + EIP-7951 P256VERIFY). Base names this
+    /// hardfork "Azul"; see [`base::AZUL`] for that alias.
+    KARST,
     /// Interop.
     INTEROP,
-    /// Azul (Base). Osaka EVM + Base-specific MODEXP / P256VERIFY precompile overlay.
-    /// Discriminant skips 110 (which would be upstream `OSAKA`) so Base Sepolia digests are
-    /// stable if an `OSAKA` variant is ever reintroduced.
-    AZUL = 111,
 }
 
 impl OpSpecId {
-    /// Converts into the corresponding revm [`SpecId`]. `AZUL` maps to `OSAKA` since Azul's
-    /// opcode-level semantics are identical to Osaka.
+    /// Converts into the corresponding revm [`SpecId`].
     #[inline]
     pub const fn into_eth_spec(self) -> SpecId {
-        match self {
-            Self::AZUL => SpecId::OSAKA,
-            Self::ISTHMUS | Self::JOVIAN | Self::INTEROP => SpecId::PRAGUE,
-            Self::ECOTONE | Self::FJORD | Self::GRANITE | Self::HOLOCENE => SpecId::CANCUN,
-            Self::CANYON => SpecId::SHANGHAI,
-            Self::BEDROCK | Self::REGOLITH => SpecId::MERGE,
-        }
+        to_op_revm(self).into_eth_spec()
     }
 }
 
-/// Conversion into op-revm's [`OpRevmSpecId`] for revm-level dispatch. `AZUL` maps to
-/// [`OpRevmSpecId::KARST`] — Azul's opcode-level semantics match Karst (op-revm 20's rename
-/// of the former `OSAKA` variant); the Base-specific precompile overlay is applied separately
-/// by the factory, which branches on `OpSpecId::AZUL` before the conversion happens.
+#[inline]
+const fn to_op_revm(spec: OpSpecId) -> OpRevmSpecId {
+    match spec {
+        OpSpecId::INTEROP => OpRevmSpecId::INTEROP,
+        OpSpecId::KARST => OpRevmSpecId::KARST,
+        OpSpecId::JOVIAN => OpRevmSpecId::JOVIAN,
+        OpSpecId::ISTHMUS => OpRevmSpecId::ISTHMUS,
+        OpSpecId::HOLOCENE => OpRevmSpecId::HOLOCENE,
+        OpSpecId::GRANITE => OpRevmSpecId::GRANITE,
+        OpSpecId::FJORD => OpRevmSpecId::FJORD,
+        OpSpecId::ECOTONE => OpRevmSpecId::ECOTONE,
+        OpSpecId::CANYON => OpRevmSpecId::CANYON,
+        OpSpecId::REGOLITH => OpRevmSpecId::REGOLITH,
+        OpSpecId::BEDROCK => OpRevmSpecId::BEDROCK,
+    }
+}
+
 impl From<OpSpecId> for OpRevmSpecId {
+    #[inline]
     fn from(spec: OpSpecId) -> Self {
-        match spec {
-            OpSpecId::AZUL => Self::KARST,
-            OpSpecId::INTEROP => Self::INTEROP,
-            OpSpecId::JOVIAN => Self::JOVIAN,
-            OpSpecId::ISTHMUS => Self::ISTHMUS,
-            OpSpecId::HOLOCENE => Self::HOLOCENE,
-            OpSpecId::GRANITE => Self::GRANITE,
-            OpSpecId::FJORD => Self::FJORD,
-            OpSpecId::ECOTONE => Self::ECOTONE,
-            OpSpecId::CANYON => Self::CANYON,
-            OpSpecId::REGOLITH => Self::REGOLITH,
-            OpSpecId::BEDROCK => Self::BEDROCK,
-        }
+        to_op_revm(spec)
     }
 }
 
@@ -129,8 +106,8 @@ impl fmt::Display for OpSpecId {
             Self::HOLOCENE => name::HOLOCENE,
             Self::ISTHMUS => name::ISTHMUS,
             Self::JOVIAN => name::JOVIAN,
+            Self::KARST => name::KARST,
             Self::INTEROP => name::INTEROP,
-            Self::AZUL => "Azul",
         })
     }
 }
@@ -150,73 +127,41 @@ impl EvmSpecId for OpSpecId {
     }
 }
 
-/// Precompile set for the Base Azul hardfork.
-///
-/// Mirrors `BasePrecompiles::azul()` from `base/base`: op-revm's `jovian()` set plus the
-/// upstream `modexp::OSAKA` (EIP-7823 input cap + EIP-7883 gas) and `secp256r1::P256VERIFY_OSAKA`
-/// (EIP-7951, 6,900 gas) precompiles. op-revm's own `OpRevmSpecId::KARST` still resolves to the
-/// `jovian()` set as a placeholder, so Steel applies this overlay itself when `AZUL` is active.
-pub(super) fn azul_precompiles() -> &'static Precompiles {
-    static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
-    INSTANCE.get_or_init(|| {
-        let mut precompiles = op_precompiles::jovian().clone();
-        precompiles.extend([modexp::OSAKA, secp256r1::P256VERIFY_OSAKA]);
-        precompiles
-    })
+/// Base-specific aliases. Base names its Karst-equivalent hardfork "Azul"; this module
+/// exposes that name as a constant so chain-spec literals read naturally without
+/// introducing a parallel `BaseSpecId` enum.
+pub mod base {
+    use super::OpSpecId;
+
+    /// Base's name for the Karst-equivalent EVM/precompile fork. EVM-level behavior is
+    /// identical to [`OpSpecId::KARST`]: Osaka EVM + EIP-7823/7883 MODEXP + EIP-7951
+    /// P256VERIFY. Used by Base Sepolia / Base Mainnet chain specs.
+    pub const AZUL: OpSpecId = OpSpecId::KARST;
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use risc0_steel::revm::precompile::{PrecompileHalt, bn254};
 
-    fn encode_length(len: usize) -> [u8; 32] {
-        let mut encoded = [0u8; 32];
-        encoded[24..].copy_from_slice(&(len as u64).to_be_bytes());
-        encoded
-    }
-
-    fn modexp_input(base_len: usize, exp_len: usize, mod_len: usize) -> Vec<u8> {
-        let mut input = Vec::new();
-        input.extend_from_slice(&encode_length(base_len));
-        input.extend_from_slice(&encode_length(exp_len));
-        input.extend_from_slice(&encode_length(mod_len));
-        input.extend(vec![1u8; base_len + exp_len + mod_len]);
-        input
+    #[test]
+    fn karst_maps_to_osaka() {
+        assert_eq!(OpSpecId::KARST.into_eth_spec(), SpecId::OSAKA);
+        assert_eq!(OpRevmSpecId::from(OpSpecId::KARST), OpRevmSpecId::KARST);
     }
 
     #[test]
-    fn azul_spec_conversion() {
-        assert_eq!(OpSpecId::AZUL.into_eth_spec(), SpecId::OSAKA);
-        assert_eq!(OpRevmSpecId::from(OpSpecId::AZUL), OpRevmSpecId::KARST);
+    fn base_azul_aliases_karst() {
+        assert_eq!(base::AZUL, OpSpecId::KARST);
     }
 
     #[test]
-    fn overlay_installs_osaka_precompiles() {
-        let p = azul_precompiles();
-
-        // modexp at 0x05 is the Osaka variant (EIP-7823 rejects fields > 1024 bytes).
-        let modexp = p.get(modexp::OSAKA.address()).unwrap();
-        let out = modexp
-            .execute(&modexp_input(1025, 0, 1), u64::MAX, 0)
-            .unwrap();
-        assert_eq!(
-            out.halt_reason(),
-            Some(&PrecompileHalt::ModexpEip7823LimitSize)
-        );
-
-        // p256verify at 0x100 is the Osaka variant (6,900 gas, not Fjord's 3,450).
-        let p256 = p.get(secp256r1::P256VERIFY_OSAKA.address()).unwrap();
-        let out = p256.execute(&[], 3_450, 0).unwrap();
-        assert_eq!(out.halt_reason(), Some(&PrecompileHalt::OutOfGas));
-    }
-
-    #[test]
-    fn overlay_preserves_jovian_bn254_pair_limit() {
-        // The `extend()` in `azul_precompiles` must not clobber Jovian's bn254-pair override.
-        let pair = azul_precompiles().get(&bn254::pair::ADDRESS).unwrap();
-        let oversized = vec![0u8; op_precompiles::bn254_pair::JOVIAN_MAX_INPUT_SIZE + 1];
-        let out = pair.execute(&oversized, u64::MAX, 0).unwrap();
-        assert_eq!(out.halt_reason(), Some(&PrecompileHalt::Bn254PairLength));
+    fn discriminants_match_op_revm() {
+        // Steel's enum exists only because of the orphan rule; its discriminants must
+        // stay aligned with op-revm so chain-spec digests aren't tied to a Steel-local
+        // numbering that could drift.
+        assert_eq!(OpSpecId::BEDROCK as u8, OpRevmSpecId::BEDROCK as u8);
+        assert_eq!(OpSpecId::JOVIAN as u8, OpRevmSpecId::JOVIAN as u8);
+        assert_eq!(OpSpecId::KARST as u8, OpRevmSpecId::KARST as u8);
+        assert_eq!(OpSpecId::INTEROP as u8, OpRevmSpecId::INTEROP as u8);
     }
 }

--- a/crates/op-steel/src/optimism/spec.rs
+++ b/crates/op-steel/src/optimism/spec.rs
@@ -14,116 +14,91 @@
 
 //! Spec-id plumbing for Optimism-family chains.
 //!
-//! Defines [`OpSpecId`], the Optimism/Base hardfork spec used by Steel. The enum mirrors
-//! op-revm's [`OpRevmSpecId`] one-to-one — it exists locally only so [`EvmSpecId`] can be
-//! implemented on it (orphan rule blocks the impl on `op_revm::OpSpecId` from this crate).
+//! [`OpSpecId`] is a thin newtype around [`OpRevmSpecId`] (re-exported from op-revm) used
+//! as Steel's [`EvmFactory::SpecId`](risc0_steel::EvmFactory::SpecId). The wrapper exists
+//! only because the orphan rule blocks `impl EvmSpecId for op_revm::OpSpecId` from this
+//! crate; all variant data still lives upstream.
 
-use op_revm::spec::{OpSpecId as OpRevmSpecId, name};
+pub use op_revm::spec::OpSpecId as OpRevmSpecId;
 use risc0_steel::{EvmSpecId, revm::primitives::hardfork::SpecId};
 use std::fmt;
 
 /// [EvmFactory::SpecId](risc0_steel::EvmFactory::SpecId) for Optimism-family chains.
 ///
-/// Mirrors [`OpRevmSpecId`] from op-revm 20: variants and discriminants are identical, and
-/// [`From<OpSpecId>`] for both [`OpRevmSpecId`] and [`SpecId`] are pure passthroughs to the
-/// upstream conversions. Steel maintains its own copy only because [`EvmSpecId`] is defined
-/// here and the orphan rule blocks implementing it directly on [`OpRevmSpecId`].
-///
-/// Base's "Azul" hardfork is the same as upstream `Karst` at the EVM/precompile level
-/// (Osaka EVM + EIP-7823/7883 MODEXP + EIP-7951 P256VERIFY); see [`base::AZUL`] for a
-/// chain-spec-friendly alias.
-#[repr(u8)]
+/// Thin newtype around [`OpRevmSpecId`]; convertible in both directions via [`From`].
 #[derive(Debug, Default, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[allow(non_camel_case_types)]
-pub enum OpSpecId {
-    /// Bedrock.
-    BEDROCK = 100,
-    /// Regolith.
-    REGOLITH,
-    /// Canyon.
-    CANYON,
-    /// Ecotone.
-    ECOTONE,
-    /// Fjord.
-    FJORD,
-    /// Granite.
-    GRANITE,
-    /// Holocene.
-    HOLOCENE,
-    /// Isthmus.
-    ISTHMUS,
-    /// Jovian.
-    #[default]
-    JOVIAN,
-    /// Karst (Osaka EVM + EIP-7823/7883 MODEXP + EIP-7951 P256VERIFY). Base names this
-    /// hardfork "Azul"; see [`base::AZUL`] for that alias.
-    KARST,
-    /// Interop.
-    INTEROP,
-}
+pub struct OpSpecId(OpRevmSpecId);
 
 impl OpSpecId {
+    /// Bedrock.
+    pub const BEDROCK: Self = Self(OpRevmSpecId::BEDROCK);
+    /// Regolith.
+    pub const REGOLITH: Self = Self(OpRevmSpecId::REGOLITH);
+    /// Canyon.
+    pub const CANYON: Self = Self(OpRevmSpecId::CANYON);
+    /// Ecotone.
+    pub const ECOTONE: Self = Self(OpRevmSpecId::ECOTONE);
+    /// Fjord.
+    pub const FJORD: Self = Self(OpRevmSpecId::FJORD);
+    /// Granite.
+    pub const GRANITE: Self = Self(OpRevmSpecId::GRANITE);
+    /// Holocene.
+    pub const HOLOCENE: Self = Self(OpRevmSpecId::HOLOCENE);
+    /// Isthmus.
+    pub const ISTHMUS: Self = Self(OpRevmSpecId::ISTHMUS);
+    /// Jovian.
+    pub const JOVIAN: Self = Self(OpRevmSpecId::JOVIAN);
+    /// Karst (Osaka EVM + EIP-7823/7883 MODEXP + EIP-7951 P256VERIFY). Base names this
+    /// hardfork "Azul"; see [`base::AZUL`] for that alias.
+    pub const KARST: Self = Self(OpRevmSpecId::KARST);
+    /// Interop.
+    pub const INTEROP: Self = Self(OpRevmSpecId::INTEROP);
+
+    /// Returns the underlying [`OpRevmSpecId`].
+    #[inline]
+    pub const fn into_inner(self) -> OpRevmSpecId {
+        self.0
+    }
+
     /// Converts into the corresponding revm [`SpecId`].
     #[inline]
     pub const fn into_eth_spec(self) -> SpecId {
-        to_op_revm(self).into_eth_spec()
+        self.0.into_eth_spec()
     }
 }
 
-#[inline]
-const fn to_op_revm(spec: OpSpecId) -> OpRevmSpecId {
-    match spec {
-        OpSpecId::INTEROP => OpRevmSpecId::INTEROP,
-        OpSpecId::KARST => OpRevmSpecId::KARST,
-        OpSpecId::JOVIAN => OpRevmSpecId::JOVIAN,
-        OpSpecId::ISTHMUS => OpRevmSpecId::ISTHMUS,
-        OpSpecId::HOLOCENE => OpRevmSpecId::HOLOCENE,
-        OpSpecId::GRANITE => OpRevmSpecId::GRANITE,
-        OpSpecId::FJORD => OpRevmSpecId::FJORD,
-        OpSpecId::ECOTONE => OpRevmSpecId::ECOTONE,
-        OpSpecId::CANYON => OpRevmSpecId::CANYON,
-        OpSpecId::REGOLITH => OpRevmSpecId::REGOLITH,
-        OpSpecId::BEDROCK => OpRevmSpecId::BEDROCK,
+impl fmt::Display for OpSpecId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(<&'static str>::from(self.0))
+    }
+}
+
+impl From<OpRevmSpecId> for OpSpecId {
+    #[inline]
+    fn from(spec: OpRevmSpecId) -> Self {
+        Self(spec)
     }
 }
 
 impl From<OpSpecId> for OpRevmSpecId {
     #[inline]
     fn from(spec: OpSpecId) -> Self {
-        to_op_revm(spec)
-    }
-}
-
-impl fmt::Display for OpSpecId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(match self {
-            Self::BEDROCK => name::BEDROCK,
-            Self::REGOLITH => name::REGOLITH,
-            Self::CANYON => name::CANYON,
-            Self::ECOTONE => name::ECOTONE,
-            Self::FJORD => name::FJORD,
-            Self::GRANITE => name::GRANITE,
-            Self::HOLOCENE => name::HOLOCENE,
-            Self::ISTHMUS => name::ISTHMUS,
-            Self::JOVIAN => name::JOVIAN,
-            Self::KARST => name::KARST,
-            Self::INTEROP => name::INTEROP,
-        })
+        spec.0
     }
 }
 
 impl EvmSpecId for OpSpecId {
     #[inline]
     fn has_eip4788(&self) -> bool {
-        *self >= Self::ECOTONE
+        self.0 >= OpRevmSpecId::ECOTONE
     }
     #[inline]
     fn has_eip2935(&self) -> bool {
-        *self >= Self::ISTHMUS
+        self.0 >= OpRevmSpecId::ISTHMUS
     }
     #[inline]
     fn to_u32(&self) -> u32 {
-        *self as u32
+        self.0 as u32
     }
 }
 
@@ -155,13 +130,7 @@ mod tests {
     }
 
     #[test]
-    fn discriminants_match_op_revm() {
-        // Steel's enum exists only because of the orphan rule; its discriminants must
-        // stay aligned with op-revm so chain-spec digests aren't tied to a Steel-local
-        // numbering that could drift.
-        assert_eq!(OpSpecId::BEDROCK as u8, OpRevmSpecId::BEDROCK as u8);
-        assert_eq!(OpSpecId::JOVIAN as u8, OpRevmSpecId::JOVIAN as u8);
-        assert_eq!(OpSpecId::KARST as u8, OpRevmSpecId::KARST as u8);
-        assert_eq!(OpSpecId::INTEROP as u8, OpRevmSpecId::INTEROP as u8);
+    fn display_uses_op_revm_names() {
+        assert_eq!(OpSpecId::KARST.to_string(), "Karst");
     }
 }

--- a/crates/op-steel/src/optimism/spec.rs
+++ b/crates/op-steel/src/optimism/spec.rs
@@ -30,6 +30,12 @@ use std::fmt;
 pub struct OpSpecId(OpRevmSpecId);
 
 impl OpSpecId {
+    /// Wraps an [`OpRevmSpecId`]. `const`-friendly counterpart to [`From::from`].
+    #[inline]
+    pub const fn new(spec: OpRevmSpecId) -> Self {
+        Self(spec)
+    }
+
     /// Returns the underlying [`OpRevmSpecId`].
     #[inline]
     pub const fn into_inner(self) -> OpRevmSpecId {

--- a/crates/op-steel/src/optimism/spec.rs
+++ b/crates/op-steel/src/optimism/spec.rs
@@ -30,30 +30,6 @@ use std::fmt;
 pub struct OpSpecId(OpRevmSpecId);
 
 impl OpSpecId {
-    /// Bedrock.
-    pub const BEDROCK: Self = Self(OpRevmSpecId::BEDROCK);
-    /// Regolith.
-    pub const REGOLITH: Self = Self(OpRevmSpecId::REGOLITH);
-    /// Canyon.
-    pub const CANYON: Self = Self(OpRevmSpecId::CANYON);
-    /// Ecotone.
-    pub const ECOTONE: Self = Self(OpRevmSpecId::ECOTONE);
-    /// Fjord.
-    pub const FJORD: Self = Self(OpRevmSpecId::FJORD);
-    /// Granite.
-    pub const GRANITE: Self = Self(OpRevmSpecId::GRANITE);
-    /// Holocene.
-    pub const HOLOCENE: Self = Self(OpRevmSpecId::HOLOCENE);
-    /// Isthmus.
-    pub const ISTHMUS: Self = Self(OpRevmSpecId::ISTHMUS);
-    /// Jovian.
-    pub const JOVIAN: Self = Self(OpRevmSpecId::JOVIAN);
-    /// Karst (Osaka EVM + EIP-7823/7883 MODEXP + EIP-7951 P256VERIFY). Base names this
-    /// hardfork "Azul"; see [`base::AZUL`] for that alias.
-    pub const KARST: Self = Self(OpRevmSpecId::KARST);
-    /// Interop.
-    pub const INTEROP: Self = Self(OpRevmSpecId::INTEROP);
-
     /// Returns the underlying [`OpRevmSpecId`].
     #[inline]
     pub const fn into_inner(self) -> OpRevmSpecId {
@@ -106,31 +82,10 @@ impl EvmSpecId for OpSpecId {
 /// exposes that name as a constant so chain-spec literals read naturally without
 /// introducing a parallel `BaseSpecId` enum.
 pub mod base {
-    use super::OpSpecId;
+    use super::OpRevmSpecId;
 
     /// Base's name for the Karst-equivalent EVM/precompile fork. EVM-level behavior is
-    /// identical to [`OpSpecId::KARST`]: Osaka EVM + EIP-7823/7883 MODEXP + EIP-7951
+    /// identical to [`OpRevmSpecId::KARST`]: Osaka EVM + EIP-7823/7883 MODEXP + EIP-7951
     /// P256VERIFY. Used by Base Sepolia / Base Mainnet chain specs.
-    pub const AZUL: OpSpecId = OpSpecId::KARST;
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn karst_maps_to_osaka() {
-        assert_eq!(OpSpecId::KARST.into_eth_spec(), SpecId::OSAKA);
-        assert_eq!(OpRevmSpecId::from(OpSpecId::KARST), OpRevmSpecId::KARST);
-    }
-
-    #[test]
-    fn base_azul_aliases_karst() {
-        assert_eq!(base::AZUL, OpSpecId::KARST);
-    }
-
-    #[test]
-    fn display_uses_op_revm_names() {
-        assert_eq!(OpSpecId::KARST.to_string(), "Karst");
-    }
+    pub const AZUL: OpRevmSpecId = OpRevmSpecId::KARST;
 }

--- a/crates/op-steel/tests/op-steel.rs
+++ b/crates/op-steel/tests/op-steel.rs
@@ -22,7 +22,7 @@ use alloy_primitives::{Address, U256, address};
 use risc0_op_steel::{
     Contract,
     config::ChainSpec,
-    optimism::{OpCallError, OpChainSpec, OpEvmEnv, OpSpecId, Optimism},
+    optimism::{OpCallError, OpChainSpec, OpEvmEnv, OpRevmSpecId, Optimism},
 };
 use std::{fmt::Debug, sync::LazyLock};
 use test_log::test;
@@ -55,7 +55,7 @@ alloy::sol!(
 );
 
 static OP_ANVIL_CHAIN_SPEC: LazyLock<OpChainSpec> =
-    LazyLock::new(|| ChainSpec::new_single(31337, OpSpecId::ISTHMUS));
+    LazyLock::new(|| ChainSpec::new_single(31337, OpRevmSpecId::ISTHMUS.into()));
 
 /// Returns an Anvil provider with the deployed [Test] contract.
 async fn test_provider() -> impl Provider<Optimism> + Clone {

--- a/crates/steel/src/ethereum.rs
+++ b/crates/steel/src/ethereum.rs
@@ -233,8 +233,7 @@ impl EvmBlockHeader for EthBlockHeader {
             difficulty: header.difficulty,
             prevrandao: (spec >= SpecId::MERGE).then_some(header.mix_hash),
             blob_excess_gas_and_price,
-            // TODO(https://github.com/boundless-xyz/steel/issues/112): populate from header once alloy supports EIP-7843
-            slot_num: 0,
+            slot_num: header.slot_number.unwrap_or_default(),
         }
     }
 }

--- a/examples/erc20-counter/Cargo.toml
+++ b/examples/erc20-counter/Cargo.toml
@@ -16,9 +16,9 @@ risc0-zkvm = { version = "3.0" }
 risc0-ethereum-contracts = { version = "3.0" }
 risc0-build-ethereum = { version = "3.0" }
 
-alloy = { version = "1.0" }
-alloy-primitives = { version = "1.0", features = ["serde"] }
-alloy-sol-types = { version = "1.0" }
+alloy = { version = "2.0" }
+alloy-primitives = { version = "1.5", features = ["serde"] }
+alloy-sol-types = { version = "1.5" }
 anyhow = { version = "1.0.75" }
 clap = { version = "4.5" }
 dotenvy = { version = "0.15" }

--- a/examples/erc20/Cargo.toml
+++ b/examples/erc20/Cargo.toml
@@ -10,8 +10,8 @@ risc0-steel = { path = "../../crates/steel" }
 risc0-build = { version = "3.0" }
 risc0-zkvm = { version = "3.0" }
 
-alloy-primitives = { version = "1.0" }
-alloy-sol-types = { version = "1.0" }
+alloy-primitives = { version = "1.5" }
+alloy-sol-types = { version = "1.5" }
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive", "env"] }
 erc20-methods = { path = "methods" }

--- a/examples/erc20/methods/guest/Cargo.toml
+++ b/examples/erc20/methods/guest/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 
 [dependencies]
 alloy-primitives = { version = "1.5.3", features = ["tiny-keccak"] }
-alloy-sol-types = { version = "1.0" }
+alloy-sol-types = { version = "1.5" }
 risc0-steel = { path = "../../../../crates/steel" }
 risc0-zkvm = { version = "3.0", default-features = false, features = ["std"] }
 

--- a/examples/events/Cargo.toml
+++ b/examples/events/Cargo.toml
@@ -10,8 +10,8 @@ risc0-steel = { path = "../../crates/steel" }
 risc0-build = { version = "3.0" }
 risc0-zkvm = { version = "3.0" }
 
-alloy-primitives = { version = "1.0" }
-alloy-sol-types = { version = "1.0" }
+alloy-primitives = { version = "1.5" }
+alloy-sol-types = { version = "1.5" }
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive", "env"] }
 events-methods = { path = "methods" }

--- a/examples/events/methods/guest/Cargo.toml
+++ b/examples/events/methods/guest/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 
 [dependencies]
 alloy-primitives = { version = "1.5.3", features = ["tiny-keccak"] }
-alloy-sol-types = { version = "1.0" }
+alloy-sol-types = { version = "1.5" }
 risc0-steel = { path = "../../../../crates/steel" }
 risc0-zkvm = { version = "3.0", default-features = false, features = ["std"] }
 

--- a/examples/op/Cargo.toml
+++ b/examples/op/Cargo.toml
@@ -7,7 +7,7 @@ debug = 1
 lto = true
 
 [workspace.dependencies]
-alloy = "1.0"
+alloy = "2.0"
 examples-common = { path = "common" }
 risc0-build = { version = "3.0" }
 risc0-ethereum-contracts = { version = "3.0" }

--- a/examples/op/l1-to-l2/core/Cargo.toml
+++ b/examples/op/l1-to-l2/core/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-alloy-primitives = "1.0"
-alloy-sol-types = "1.0"
+alloy-primitives = "1.5"
+alloy-sol-types = "1.5"

--- a/examples/op/l2-to-l1/core/Cargo.toml
+++ b/examples/op/l2-to-l1/core/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-alloy-primitives = "1.0"
-alloy-sol-types = "1.0"
+alloy-primitives = "1.5"
+alloy-sol-types = "1.5"

--- a/examples/op/l2/core/Cargo.toml
+++ b/examples/op/l2/core/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-alloy-primitives = "1.0"
-alloy-sol-types = "1.0"
+alloy-primitives = "1.5"
+alloy-sol-types = "1.5"

--- a/examples/token-stats/Cargo.toml
+++ b/examples/token-stats/Cargo.toml
@@ -10,10 +10,10 @@ risc0-steel = { path = "../../crates/steel" }
 risc0-build = { version = "3.0" }
 risc0-zkvm = { version = "3.0" }
 
-alloy-primitives = { version = "1.0", features = ["serde", "rlp", "std"] }
+alloy-primitives = { version = "1.5", features = ["serde", "rlp", "std"] }
 alloy-rlp = { version = "0.3", default-features = false }
 alloy-rlp-derive = { version = "0.3", default-features = false }
-alloy-sol-types = { version = "1.0" }
+alloy-sol-types = { version = "1.5" }
 anyhow = "1.0"
 clap = { version = "4.4", features = ["derive", "env"] }
 log = "0.4"

--- a/examples/token-stats/methods/guest/Cargo.toml
+++ b/examples/token-stats/methods/guest/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 
 [dependencies]
 alloy-primitives = { version = "1.5.3", features = ["tiny-keccak"] }
-alloy-sol-types = { version = "1.0" }
+alloy-sol-types = { version = "1.5" }
 risc0-steel = { path = "../../../../crates/steel" }
 risc0-zkvm = { version = "3.0", default-features = false, features = ["std"] }
 token-stats-core = { path = "../../core" }


### PR DESCRIPTION
## Summary

Pins the alloy/revm dependency tree to versions that **alloy-evm 0.33.3 and alloy-op-evm 0.32.0 transitively pin themselves**, so steel resolves the same minor.patch as upstream:

| Crate | Before | After |
|---|---|---|
| `alloy` | 1.0 | **2.0** |
| `alloy-consensus` / `-eips` / `-rpc-types` | 1.0 | **2.0** |
| `alloy-primitives` / `-sol-types` | 1.3 | **1.5** |
| `alloy-evm` | 0.30 | **0.33** |
| `alloy-op-evm` | 0.30 | **0.32** |
| `revm` | 36.0 | **38.0** |
| `op-revm` | 17.0 | **20.0** |
| `op-alloy-{consensus,rpc-types}` | 0.24 | **2.0** |
| `op-alloy-network` | (vendored) | **2.0** |
| `alloy-trie` | 0.8 | 0.8 (kept — 0.9 is a major `nybbles` refactor) |

`alloy-evm 0.34.0` is intentionally **not** picked up: `alloy-op-evm 0.32.0` still pins `alloy-evm = ^0.33`, so 0.34 isn't usable until `alloy-op-evm 0.33` is published.

### Closes #116

Drops the vendored `Optimism` network type now that `op-alloy-network 2.0.0` ships the upstream `NetworkWallet<Optimism>` conflict fix. `op-steel` now re-exports `op_alloy_network::Optimism` directly (host-only).

### Closes #112

Populates `BlockEnv::slot_num` from the new `Header.slot_number` field (alloy 2.0, EIP-7843) in both `crates/steel/src/ethereum.rs` and `crates/op-steel/src/optimism/mod.rs`.

### Collapses #120's Azul overlay onto upstream KARST

PR #120 introduced `OpSpecId::AZUL` plus a Steel-local `azul_precompiles()` overlay because op-revm 17's `OpSpecId::OSAKA` was a placeholder mapping to `jovian()` precompiles — there was no upstream spec that actually installed the Osaka MODEXP (EIP-7823/7883) and P256VERIFY (EIP-7951) precompile upgrades. op-revm 20 fills that gap: `KARST` is the renamed `OSAKA`, and `OpPrecompiles::new_with_spec(KARST)` produces a precompile set that matches Steel's `azul_precompiles()` byte-for-byte (verified against `base/node-reth`'s `BasePrecompiles::azul()` reference).

With the upstream wiring in place:

- Drop `OpSpecId::AZUL`, `azul_precompiles()`, and the spec.rs overlay tests.
- Drop the `matches!(spec_id, AZUL)` branch in `OpEvmFactory::create_evm` — the default `AlloyOpEvmFactory::create_evm` now picks up the right precompiles via the spec mapping.
- **`OpSpecId` is now a thin newtype around `op_revm::OpSpecId`** (re-exported as `OpRevmSpecId`). Steel keeps the local wrapper only because the orphan rule blocks `impl EvmSpecId for op_revm::OpSpecId` from `op-steel`. All variant data lives upstream; new forks flow through automatically.
- **`optimism::base::AZUL`** is a constant aliasing `OpRevmSpecId::KARST` so chain-spec literals stay readable for Base chains.
- Chain-spec literals lift `[(OpRevmSpecId, FC); N]` arrays through a private `forks()` helper into the `(OpSpecId, FC)` form `ChainSpec` expects, keeping each entry on a single line and removing per-entry `.into()` noise.

### Schedules Base Mainnet Azul

Base announced their Mainnet Azul activation in `base/node-reth` at `azul_timestamp = 1_779_386_400` (2026-05-21 18:00 UTC, ~16 days from PR open). `BASE_MAINNET_CHAIN_SPEC` now activates Azul at that timestamp; cross-checked against `ethereum-optimism/superchain-registry` (OP chains, no Karst/Interop scheduled) and `base/node-reth` (Base chains).

### Other fallout from the bump

- **revm-precompile 34 split `PrecompileError`** into a fatal `Error` and a non-fatal `Halt` (`PrecompileHalt`). No longer affects Steel directly since the Azul overlay tests were dropped.
- **alloy-op-evm 0.32 swapped the `OpEvm` context tx type** from `OpTransaction<TxEnv>` to `OpTx`. Since the AZUL factory branch is gone, Steel just uses `AlloyOpEvmFactory::create_evm` for all specs — the upstream factory handles the new tx type internally.
