### PR TITLE
ci: validate v3.0.0 release content

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -275,7 +275,7 @@ jobs:
       - uses: risc0/risc0/.github/actions/rustup@352dea62857ba57331053cd0986a12c1a4708732
         with:
           # Building with docs.rs config requires the nightly toolchain.
-          toolchain: nightly-2025-10-30
-      - run: cargo +nightly-2025-10-30 doc -p risc0-steel --all-features --no-deps
+          toolchain: nightly-2026-06-01
+      - run: cargo +nightly-2026-06-01 doc -p risc0-steel --all-features --no-deps
         env:
           RUSTDOCFLAGS: "--cfg docsrs -D warnings"

--- a/.github/workflows/steel-documentation.yml
+++ b/.github/workflows/steel-documentation.yml
@@ -30,11 +30,11 @@ jobs:
 
       - uses: risc0/risc0/.github/actions/rustup@main
         with:
-          toolchain: nightly-2025-10-30
+          toolchain: nightly-2026-06-01
 
       - name: Build documentation
         run: |
-          if ! cargo +nightly-2025-10-30 doc -p risc0-steel --all-features --no-deps; then
+          if ! cargo +nightly-2026-06-01 doc -p risc0-steel --all-features --no-deps; then
             echo "Documentation build failed"
             exit 1
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This release deliberately keeps the audit-relevant surface minimal: it introduce
 ### ⚙️ Miscellaneous
 
 - Remove the `alloy-network` < 1.7.4 pin in `risc0-op-steel`; `op-alloy-network` 2.0 ships the upstream `NetworkWallet<Optimism>` conflict fix.
+- Gate `op-alloy-network` behind the `host` feature of `risc0-op-steel`: version 2.0 depends on `alloy-provider`, which would otherwise pull host networking crates into guest builds. The guest-side OP header type is `alloy_consensus::Header` directly (the identical type); `op_alloy_network::Optimism` is still re-exported with the `host` feature.
 
 ## [2.4.4](https://github.com/boundless-xyz/steel/releases/tag/v2.4.4)
 

--- a/contracts/src/Steel.sol
+++ b/contracts/src/Steel.sol
@@ -1,4 +1,4 @@
-// Copyright 2025 RISC Zero, Inc.
+// Copyright 2026 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/crates/op-steel/Cargo.toml
+++ b/crates/op-steel/Cargo.toml
@@ -14,6 +14,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 alloy = { workspace = true, optional = true, features = ["std", "essentials"] }
+alloy-consensus = { workspace = true }
 alloy-eips = { workspace = true }
 alloy-evm = { workspace = true }
 alloy-op-evm = { workspace = true }
@@ -21,7 +22,7 @@ alloy-primitives = { workspace = true, features = ["rlp", "serde"] }
 alloy-sol-types = { workspace = true }
 anyhow = { workspace = true }
 log = { workspace = true }
-op-alloy-network = { workspace = true }
+op-alloy-network = { workspace = true, optional = true }
 op-revm = { workspace = true, features = ["serde"] }
 risc0-steel = { workspace = true }
 serde = { workspace = true }
@@ -32,6 +33,6 @@ url = { workspace = true, optional = true }
 
 [features]
 default = []
-host = ["dep:alloy", "dep:tokio", "dep:url", "risc0-steel/host", "alloy-primitives/rand"]
+host = ["dep:alloy", "dep:op-alloy-network", "dep:tokio", "dep:url", "risc0-steel/host", "alloy-primitives/rand"]
 reqwest-native-tls = ["alloy?/reqwest-native-tls", "risc0-steel/reqwest-native-tls"]
 reqwest-rustls-tls = ["alloy?/reqwest-rustls-tls", "risc0-steel/reqwest-rustls-tls"]

--- a/crates/op-steel/src/optimism/host.rs
+++ b/crates/op-steel/src/optimism/host.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 RISC Zero, Inc.
+// Copyright 2026 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/crates/op-steel/src/optimism/host.rs
+++ b/crates/op-steel/src/optimism/host.rs
@@ -37,6 +37,13 @@ use std::{
 };
 use url::Url;
 
+// compile-time check: the guest-side OpHeader avoids the op-alloy-network dependency, so it must
+// stay the exact type that the upstream Optimism network declares as its header
+#[allow(dead_code)]
+fn assert_op_header_type(header: <Optimism as alloy::network::Network>::Header) -> super::OpHeader {
+    header
+}
+
 /// Wrapped [EvmEnv] for Optimism.
 pub struct OpEvmEnv<D, C> {
     /// Underlying generic environment without a specific commitment.

--- a/crates/op-steel/src/optimism/host.rs
+++ b/crates/op-steel/src/optimism/host.rs
@@ -18,7 +18,7 @@ use crate::{
     DisputeGameCommit,
 };
 use alloy::{
-    network::Ethereum,
+    network::{Ethereum, Network},
     providers::{Provider, ProviderBuilder, RootProvider},
 };
 use alloy_primitives::{Address, Sealable};
@@ -40,7 +40,7 @@ use url::Url;
 // compile-time check: the guest-side OpHeader avoids the op-alloy-network dependency, so it must
 // stay the exact type that the upstream Optimism network declares as its header
 #[allow(dead_code)]
-fn assert_op_header_type(header: <Optimism as alloy::network::Network>::Header) -> super::OpHeader {
+fn assert_op_header_type(header: <Optimism as Network>::Header) -> super::OpHeader {
     header
 }
 

--- a/crates/op-steel/src/optimism/host.rs
+++ b/crates/op-steel/src/optimism/host.rs
@@ -23,7 +23,7 @@ use alloy::{
 };
 use alloy_primitives::{Address, Sealable};
 use anyhow::{Context, Result};
-use op_alloy_network::Optimism;
+pub use op_alloy_network::Optimism;
 use risc0_steel::{
     host::{
         db::{ProofDb, ProviderDb},

--- a/crates/op-steel/src/optimism/mod.rs
+++ b/crates/op-steel/src/optimism/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 RISC Zero, Inc.
+// Copyright 2026 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/crates/op-steel/src/optimism/mod.rs
+++ b/crates/op-steel/src/optimism/mod.rs
@@ -30,7 +30,7 @@ use risc0_steel::{
     BlockInput, Commitment, EvmBlockHeader, EvmEnv, EvmFactory, StateDb,
 };
 use serde::{Deserialize, Serialize};
-use std::{collections::BTreeMap, convert::Into, error::Error, sync::LazyLock};
+use std::{collections::BTreeMap, error::Error, sync::LazyLock};
 
 mod spec;
 pub use spec::{base, OpRevmSpecId, OpSpecId};

--- a/crates/op-steel/src/optimism/mod.rs
+++ b/crates/op-steel/src/optimism/mod.rs
@@ -17,7 +17,6 @@ use alloy_eips::{eip4844, eip7691};
 use alloy_evm::{Database, EvmFactory as AlloyEvmFactory};
 use alloy_op_evm::{OpEvmFactory as AlloyOpEvmFactory, OpTx};
 use alloy_primitives::{Address, BlockNumber, Bytes, ChainId, Sealable, TxKind, B256, U256};
-use op_alloy_network::{Network, Optimism};
 use op_revm::OpTransaction;
 use risc0_steel::{
     config::{ChainSpec, ForkCondition as FC},
@@ -170,7 +169,7 @@ impl EvmFactory for OpEvmFactory {
 /// [ChainSpec] for Optimism.
 pub type OpChainSpec = ChainSpec<OpSpecId>;
 
-type OpHeader = <Optimism as Network>::Header;
+type OpHeader = alloy_consensus::Header;
 
 /// [EvmBlockHeader] for Optimism.
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/steel/src/block.rs
+++ b/crates/steel/src/block.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 RISC Zero, Inc.
+// Copyright 2026 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/crates/steel/src/config.rs
+++ b/crates/steel/src/config.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 RISC Zero, Inc.
+// Copyright 2026 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/crates/steel/src/contract.rs
+++ b/crates/steel/src/contract.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 RISC Zero, Inc.
+// Copyright 2026 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/crates/steel/src/ethereum.rs
+++ b/crates/steel/src/ethereum.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 RISC Zero, Inc.
+// Copyright 2026 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/crates/steel/src/history/beacon_roots.rs
+++ b/crates/steel/src/history/beacon_roots.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 RISC Zero, Inc.
+// Copyright 2026 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/crates/steel/src/host/db/provider.rs
+++ b/crates/steel/src/host/db/provider.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 RISC Zero, Inc.
+// Copyright 2026 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/crates/steel/src/host/mod.rs
+++ b/crates/steel/src/host/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 RISC Zero, Inc.
+// Copyright 2026 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/erc20-counter/methods/guest/Cargo.toml
+++ b/examples/erc20-counter/methods/guest/Cargo.toml
@@ -17,8 +17,8 @@ risc0-zkvm = { version = "3.0", default-features = false, features = ["std", "un
 
 [patch.crates-io]
 # enable RISC Zero's precompiles
-blst = { git = "https://github.com/risc0/blst", tag = "v0.3.15-risczero.1" }
-c-kzg = { git = "https://github.com/risc0/c-kzg-4844", tag = "c-kzg/v2.1.1-risczero.2" }
+blst = { git = "https://github.com/risc0/blst", tag = "v0.3.16-risczero.0" }
+c-kzg = { git = "https://github.com/risc0/c-kzg-4844", tag = "v2.1.7-risczero.0" }
 crypto-bigint = { git = "https://github.com/risc0/RustCrypto-crypto-bigint", tag = "v0.5.5-risczero.0" }
 k256 = { git = "https://github.com/risc0/RustCrypto-elliptic-curves", tag = "k256/v0.13.4-risczero.1" }
 sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.9-risczero.0" }

--- a/examples/erc20/methods/guest/Cargo.toml
+++ b/examples/erc20/methods/guest/Cargo.toml
@@ -13,8 +13,8 @@ risc0-zkvm = { version = "3.0", default-features = false, features = ["std", "un
 
 [patch.crates-io]
 # enable RISC Zero's precompiles
-blst = { git = "https://github.com/risc0/blst", tag = "v0.3.15-risczero.1" }
-c-kzg = { git = "https://github.com/risc0/c-kzg-4844", tag = "c-kzg/v2.1.1-risczero.2" }
+blst = { git = "https://github.com/risc0/blst", tag = "v0.3.16-risczero.0" }
+c-kzg = { git = "https://github.com/risc0/c-kzg-4844", tag = "v2.1.7-risczero.0" }
 crypto-bigint = { git = "https://github.com/risc0/RustCrypto-crypto-bigint", tag = "v0.5.5-risczero.0" }
 k256 = { git = "https://github.com/risc0/RustCrypto-elliptic-curves", tag = "k256/v0.13.4-risczero.1" }
 sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.9-risczero.0" }

--- a/examples/events/methods/guest/Cargo.toml
+++ b/examples/events/methods/guest/Cargo.toml
@@ -13,9 +13,9 @@ risc0-zkvm = { version = "3.0", default-features = false, features = ["std", "un
 
 [patch.crates-io]
 # enable RISC Zero's precompiles
-blst = { git = "https://github.com/risc0/blst", tag = "v0.3.15-risczero.1" }
-c-kzg = { git = "https://github.com/risc0/c-kzg-4844", tag = "c-kzg/v2.1.1-risczero.2" }
+blst = { git = "https://github.com/risc0/blst", tag = "v0.3.16-risczero.0" }
+c-kzg = { git = "https://github.com/risc0/c-kzg-4844", tag = "v2.1.7-risczero.0" }
 crypto-bigint = { git = "https://github.com/risc0/RustCrypto-crypto-bigint", tag = "v0.5.5-risczero.0" }
-k256 = { git = "https://github.com/risc0/RustCrypto-elliptic-curves", tag = "k256/v0.13.3-risczero.1" }
+k256 = { git = "https://github.com/risc0/RustCrypto-elliptic-curves", tag = "k256/v0.13.4-risczero.1" }
 sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.9-risczero.0" }
 tiny-keccak = { git = "https://github.com/risc0/tiny-keccak", tag = "tiny-keccak/v2.0.2-risczero.0" }

--- a/examples/op/common/src/lib.rs
+++ b/examples/op/common/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 RISC Zero, Inc.
+// Copyright 2026 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/op/l1-to-l2/methods/guest/Cargo.toml
+++ b/examples/op/l1-to-l2/methods/guest/Cargo.toml
@@ -13,8 +13,8 @@ risc0-zkvm = { version = "3.0", default-features = false, features = ["std", "un
 
 [patch.crates-io]
 # enable RISC Zero's precompiles
-blst = { git = "https://github.com/risc0/blst", tag = "v0.3.15-risczero.1" }
-c-kzg = { git = "https://github.com/risc0/c-kzg-4844", tag = "c-kzg/v2.1.1-risczero.2" }
+blst = { git = "https://github.com/risc0/blst", tag = "v0.3.16-risczero.0" }
+c-kzg = { git = "https://github.com/risc0/c-kzg-4844", tag = "v2.1.7-risczero.0" }
 crypto-bigint = { git = "https://github.com/risc0/RustCrypto-crypto-bigint", tag = "v0.5.5-risczero.0" }
 k256 = { git = "https://github.com/risc0/RustCrypto-elliptic-curves", tag = "k256/v0.13.4-risczero.1" }
 sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.9-risczero.0" }

--- a/examples/op/l2-to-l1/methods/guest/Cargo.toml
+++ b/examples/op/l2-to-l1/methods/guest/Cargo.toml
@@ -13,8 +13,8 @@ risc0-zkvm = { version = "3.0", default-features = false, features = ["std", "un
 
 [patch.crates-io]
 # enable RISC Zero's precompiles
-blst = { git = "https://github.com/risc0/blst", tag = "v0.3.15-risczero.1" }
-c-kzg = { git = "https://github.com/risc0/c-kzg-4844", tag = "c-kzg/v2.1.1-risczero.2" }
+blst = { git = "https://github.com/risc0/blst", tag = "v0.3.16-risczero.0" }
+c-kzg = { git = "https://github.com/risc0/c-kzg-4844", tag = "v2.1.7-risczero.0" }
 crypto-bigint = { git = "https://github.com/risc0/RustCrypto-crypto-bigint", tag = "v0.5.5-risczero.0" }
 k256 = { git = "https://github.com/risc0/RustCrypto-elliptic-curves", tag = "k256/v0.13.4-risczero.1" }
 sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.9-risczero.0" }

--- a/examples/op/l2/methods/guest/Cargo.toml
+++ b/examples/op/l2/methods/guest/Cargo.toml
@@ -13,8 +13,8 @@ risc0-zkvm = { version = "3.0", default-features = false, features = ["std", "un
 
 [patch.crates-io]
 # enable RISC Zero's precompiles
-blst = { git = "https://github.com/risc0/blst", tag = "v0.3.15-risczero.1" }
-c-kzg = { git = "https://github.com/risc0/c-kzg-4844", tag = "c-kzg/v2.1.1-risczero.2" }
+blst = { git = "https://github.com/risc0/blst", tag = "v0.3.16-risczero.0" }
+c-kzg = { git = "https://github.com/risc0/c-kzg-4844", tag = "v2.1.7-risczero.0" }
 crypto-bigint = { git = "https://github.com/risc0/RustCrypto-crypto-bigint", tag = "v0.5.5-risczero.0" }
 k256 = { git = "https://github.com/risc0/RustCrypto-elliptic-curves", tag = "k256/v0.13.4-risczero.1" }
 sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.9-risczero.0" }

--- a/examples/token-stats/methods/guest/Cargo.toml
+++ b/examples/token-stats/methods/guest/Cargo.toml
@@ -14,8 +14,8 @@ token-stats-core = { path = "../../core" }
 
 [patch.crates-io]
 # enable RISC Zero's precompiles
-blst = { git = "https://github.com/risc0/blst", tag = "v0.3.15-risczero.1" }
-c-kzg = { git = "https://github.com/risc0/c-kzg-4844", tag = "c-kzg/v2.1.1-risczero.2" }
+blst = { git = "https://github.com/risc0/blst", tag = "v0.3.16-risczero.0" }
+c-kzg = { git = "https://github.com/risc0/c-kzg-4844", tag = "v2.1.7-risczero.0" }
 crypto-bigint = { git = "https://github.com/risc0/RustCrypto-crypto-bigint", tag = "v0.5.5-risczero.0" }
 k256 = { git = "https://github.com/risc0/RustCrypto-elliptic-curves", tag = "k256/v0.13.4-risczero.1" }
 sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.9-risczero.0" }


### PR DESCRIPTION
## Purpose

CI-validation PR for the **v3.0.0 release**. The `release-3.0` branch already contains the release content (it was pushed before the branch ruleset could gate it through a PR), so this PR was opened to run the CI suite against that content. The validation surfaced a few issues, so the PR now also carries the fixes for them.

The full release diff against the last release is:
https://github.com/boundless-xyz/steel/compare/v2.4.4...ci/validate-v3.0.0

## Release content being validated

- chore: bump alloy/revm/op-alloy stack to consistent set (alloy 2.0, alloy-evm 0.33, alloy-op-evm 0.32, revm 38, op-revm 20, rust 1.94)
- feat: update chain specs to latest forks (Osaka, Jovian, Hoodi, Base Mainnet/Sepolia incl. Azul)
- fix: align ChainSpec digests with main via EvmSpecId
- chore(release): Prepare for steel v3.0.0