### PR TITLE
WEB3-645: chore: declare rust-version 1.94 and bump docs nightly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -273,7 +273,7 @@ jobs:
       - uses: risc0/risc0/.github/actions/rustup@352dea62857ba57331053cd0986a12c1a4708732
         with:
           # Building with docs.rs config requires the nightly toolchain.
-          toolchain: nightly-2025-10-30
-      - run: cargo +nightly-2025-10-30 doc -p risc0-steel --all-features --no-deps
+          toolchain: nightly-2026-06-01
+      - run: cargo +nightly-2026-06-01 doc -p risc0-steel --all-features --no-deps
         env:
           RUSTDOCFLAGS: "--cfg docsrs -D warnings"

--- a/.github/workflows/steel-documentation.yml
+++ b/.github/workflows/steel-documentation.yml
@@ -30,11 +30,11 @@ jobs:
 
       - uses: risc0/risc0/.github/actions/rustup@main
         with:
-          toolchain: nightly-2025-10-30
+          toolchain: nightly-2026-06-01
 
       - name: Build documentation
         run: |
-          if ! cargo +nightly-2025-10-30 doc -p risc0-steel --all-features --no-deps; then
+          if ! cargo +nightly-2026-06-01 doc -p risc0-steel --all-features --no-deps; then
             echo "Documentation build failed"
             exit 1
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ All notable changes to this project will be documented in this file.
 - Add a warning log when the provider's chain ID does not match the chain spec configuration.
 - Improved error messages when the execution block incorrectly matches the commitment block for historical commitments.
 - Re-export `op_revm` from `risc0-op-steel`, so users can access OP-specific revm types (e.g. `OpSpecId`) without adding `op-revm` as a direct dependency.
-- Bumped Rust toolchain to 1.94.
+- Bumped Rust toolchain to 1.94 and declared it as the crates' MSRV (`rust-version`).
 - Updated dependencies: `alloy` (to 2.0), `alloy-evm` (to 0.33), `alloy-op-evm` (to 0.32), `revm` (to 38.0), `op-revm` (to 20.0), `op-alloy` (to 2.0).
 - Drop the vendored `Optimism` network type in `risc0-op-steel` in favor of `op_alloy_network::Optimism`, now that `op-alloy-network 2.0.0` ships with the upstream `NetworkWallet<Optimism>` conflict fix (closes #116).
 - Populate `BlockEnv::slot_num` from the header's new `slot_number` field (alloy 2.0, EIP-7843) in both `crates/steel/src/ethereum.rs` and `crates/op-steel/src/optimism/mod.rs` (closes #112).

--- a/crates/op-steel/Cargo.toml
+++ b/crates/op-steel/Cargo.toml
@@ -2,7 +2,7 @@
 name = "risc0-op-steel"
 description = "Optimism abstraction for Steel."
 version = "0.8.0"
-rust-version = "1.88"
+rust-version = "1.94"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/crates/op-steel/src/optimism/host.rs
+++ b/crates/op-steel/src/optimism/host.rs
@@ -37,6 +37,13 @@ use std::{
 };
 use url::Url;
 
+// compile-time check: the guest-side OpHeader avoids the op-alloy-network dependency, so it must
+// stay the exact type that the upstream Optimism network declares as its header
+#[allow(dead_code)]
+fn assert_op_header_type(header: <Optimism as alloy::network::Network>::Header) -> super::OpHeader {
+    header
+}
+
 /// Wrapped [EvmEnv] for Optimism.
 pub struct OpEvmEnv<D, C> {
     /// Underlying generic environment without a specific commitment.

--- a/crates/op-steel/src/optimism/host.rs
+++ b/crates/op-steel/src/optimism/host.rs
@@ -18,7 +18,7 @@ use crate::{
     optimism::{OpBlockHeader, OpChainSpec, OpEvmFactory, OpEvmInput},
 };
 use alloy::{
-    network::Ethereum,
+    network::{Ethereum, Network},
     providers::{Provider, ProviderBuilder, RootProvider},
 };
 use alloy_primitives::{Address, Sealable};
@@ -40,7 +40,7 @@ use url::Url;
 // compile-time check: the guest-side OpHeader avoids the op-alloy-network dependency, so it must
 // stay the exact type that the upstream Optimism network declares as its header
 #[allow(dead_code)]
-fn assert_op_header_type(header: <Optimism as alloy::network::Network>::Header) -> super::OpHeader {
+fn assert_op_header_type(header: <Optimism as Network>::Header) -> super::OpHeader {
     header
 }
 

--- a/crates/steel/Cargo.toml
+++ b/crates/steel/Cargo.toml
@@ -2,7 +2,7 @@
 name = "risc0-steel"
 description = "Query Ethereum state, or any other EVM-based blockchain state within the RISC Zero zkVM."
 version = "2.4.0"
-rust-version = "1.88"
+rust-version = "1.94"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }


### PR DESCRIPTION
## Summary

Small fixes found during the v3.0.0 release prep (#134 / `release-3.0`), ported to main:

- **Declare `rust-version = "1.94"`** in `risc0-steel` and `risc0-op-steel`. The workspace toolchain is already 1.94 and the op-alloy/op-revm dependency stack hard-requires rustc 1.94, but the crates still declared the stale `1.88`. Consumers on an older toolchain currently get a confusing dependency-level error instead of cargo's clean "package requires rustc 1.94" message.
- **Bump the docs nightly** `nightly-2025-10-30` → `nightly-2026-06-01` in the `docs-rs` CI job and the documentation workflow. The old pin identifies as rustc **1.93.0-nightly**, which cargo rejects the moment the crates declare `rust-version = "1.94"` — this is exactly the failure the release-3.0 CI hit, and main would hit it at release-prep time otherwise. (Main currently passes only because the under-declared 1.88 lets the stale nightly through the MSRV check.)
- **Add a compile-time check that `OpHeader` stays the `Optimism` network header type.** The guest-side `OpHeader` is `alloy_consensus::Header` directly, to keep `op-alloy-network` (whose `alloy-provider` dependency is mandatory) out of guest builds — but nothing tied it to `<Optimism as Network>::Header`, which upstream currently defines as exactly this type. A host-gated assertion function now makes the build fail loudly if the OP-Stack ever introduces a distinct header type, instead of silently diverging.

Also extends the existing CHANGELOG line about the 1.94 toolchain bump to mention the MSRV declaration.
